### PR TITLE
docs: Small fix to writing-marble-tests.md

### DIFF
--- a/doc/writing-marble-tests.md
+++ b/doc/writing-marble-tests.md
@@ -65,11 +65,11 @@ always represents the "zero frame". A "frame" is somewhat analogous to a virtual
 
 `'--a--'`: An observable that waits 20 "frames", emits value `a` and then never completes.
 
-`'--a--b--|`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `complete`
+`'--a--b--|'`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `complete`
 
-`'--a--b--#`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `error`
+`'--a--b--#'`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `error`
 
-`'-a-^-b--|`: In a hot observable, on frame -20 emit `a`, then on frame 20 emit `b`, and on frame 50, `complete`.
+`'-a-^-b--|'`: In a hot observable, on frame -20 emit `a`, then on frame 20 emit `b`, and on frame 50, `complete`.
 
 `'--(abc)-|'`: on frame 20, emit `a`, `b`, and `c`, then on frame 80 `complete`
 
@@ -91,7 +91,7 @@ There should be **at most one** `^` point in a subscription marble diagram, and 
 
 `'--^--'`: a subscription happened after 20 "frames" of time passed, and the subscription was not unsubscribed.
 
-`'--^--!-`: on frame 20 a subscription happened, and on frame 50 was unsubscribed.
+`'--^--!-'`: on frame 20 a subscription happened, and on frame 50 was unsubscribed.
 
 ## Anatomy of a Test
 


### PR DESCRIPTION
Description: Small fix to the examples that were missing their closing single quotation mark.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
