### PR TITLE
Update upstream

### DIFF
--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -4,7 +4,19 @@ import { Observable } from '../Observable';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../types';
+
+export function catchError<T>(
+  selector: (err: any, caught: Observable<T>) => never
+): MonoTypeOperatorFunction<T>;
+
+export function catchError<T>(
+  selector: (err: any, caught: Observable<T>) => ObservableInput<T>
+): MonoTypeOperatorFunction<T>;
+
+export function catchError<T, R>(
+  selector: (err: any, caught: Observable<T>) => ObservableInput<R>
+): OperatorFunction<T, R>;
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.
@@ -63,7 +75,7 @@ import { ObservableInput, OperatorFunction } from '../types';
  *  catch `selector` function.
  * @name catchError
  */
-export function catchError<T, R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>): OperatorFunction<T, T | R> {
+export function catchError<T, R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>|never): OperatorFunction<T, T | R> {
   return function catchErrorOperatorFunction(source: Observable<T>): Observable<T | R> {
     const operator = new CatchOperator(selector);
     const caught = source.lift(operator);


### PR DESCRIPTION
…turn (#3421)

Added per suggestion of @mprobst [here](https://github.com/ReactiveX/rxjs/issues/3395#issuecomment-371062130), it should provide slightly better type inferrence once other issues with `pipe` type inference are straightened out.

related #3395

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
