### PR TITLE
Update upstream

### DIFF
--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { onErrorResumeNext } from 'rxjs/operators';
+import { concat, throwError, of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
-describe('Observable.prototype.onErrorResumeNext', () => {
+describe('onErrorResumeNext operator', () => {
   asDiagram('onErrorResumeNext')('should continue observable sequence with next observable', () => {
     const source =  hot('--a--b--#');
     const next   = cold(        '--c--d--|');
     const subs =        '^               !';
     const expected =    '--a--b----c--d--|';
 
-    expectObservable(source.onErrorResumeNext(next)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -23,7 +22,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =        '^               !';
     const expected =    '--a--b----c--d--|';
 
-    expectObservable(source.onErrorResumeNext(next)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -35,7 +34,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^                            !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
-    expectObservable(source.onErrorResumeNext(next)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -47,7 +46,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^                            !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
-    expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next1, next2, next3))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -59,7 +58,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^                            !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
-    expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next1, next2, next3))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -71,7 +70,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^                    !';
     const expected =     '--c--d----e----f--g--|';
 
-    expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next1, next2, next3))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -81,7 +80,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^         ';
     const expected =     '--a--b----';
 
-    expectObservable(source.onErrorResumeNext(next1)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next1))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -91,7 +90,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =         '^       ';
     const expected =     '-';
 
-    expectObservable(source.onErrorResumeNext(next1)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next1))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -101,15 +100,15 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const subs =        '^               !';
     const expected =    '--a--b----c--d--|';
 
-    expectObservable(source.onErrorResumeNext(next)).toBe(expected);
+    expectObservable(source.pipe(onErrorResumeNext(next))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should work with promise', (done: MochaDone) => {
     const expected = [1, 2];
-    const source = Observable.concat(Observable.of(1), Observable.throw('meh'));
+    const source = concat(of(1), throwError('meh'));
 
-    source.onErrorResumeNext(Promise.resolve(2))
+    source.pipe(onErrorResumeNext(Promise.resolve(2)))
       .subscribe(x => {
         expect(expected.shift()).to.equal(x);
       }, (err: any) => {

--- a/spec/operators/pairwise-spec.ts
+++ b/spec/operators/pairwise-spec.ts
@@ -1,9 +1,10 @@
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { pairwise } from 'rxjs/operators';
 
 declare function asDiagram(arg: string): Function;
 
 /** @test {pairwise} */
-describe('Observable.prototype.pairwise', () => {
+describe('pairwise operator', () => {
   asDiagram('pairwise')('should group consecutive emissions as arrays of two', () => {
     const e1 =   hot('--a--b-c----d--e---|');
     const expected = '-----u-v----w--x---|';
@@ -15,7 +16,7 @@ describe('Observable.prototype.pairwise', () => {
       x: ['d', 'e']
     };
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected, values);
   });
@@ -33,7 +34,7 @@ describe('Observable.prototype.pairwise', () => {
       z: ['f', 'g']
     };
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -47,7 +48,7 @@ describe('Observable.prototype.pairwise', () => {
     const values = {
     };
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -64,7 +65,7 @@ describe('Observable.prototype.pairwise', () => {
       x: ['d', 'e']
     };
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -75,7 +76,7 @@ describe('Observable.prototype.pairwise', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -86,7 +87,7 @@ describe('Observable.prototype.pairwise', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -97,7 +98,7 @@ describe('Observable.prototype.pairwise', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const source = (<any>e1).pairwise();
+    const source = (<any>e1).pipe(pairwise());
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -1,18 +1,17 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { publish, zip, mergeMapTo, mergeMap, tap, refCount, retry, repeat, map } from 'rxjs/operators';
+import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 declare const type: Function;
 
-const Observable = Rx.Observable;
-
 /** @test {publish} */
-describe('Observable.prototype.publish', () => {
+describe('publish operator', () => {
   asDiagram('publish')('should mirror a simple source Observable', () => {
     const source = cold('--1-2---3-4--5-|');
     const sourceSubs =  '^              !';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<any>;
     const expected =    '--1-2---3-4--5-|';
 
     expectObservable(published).toBe(expected);
@@ -22,7 +21,7 @@ describe('Observable.prototype.publish', () => {
   });
 
   it('should return a ConnectableObservable-ish', () => {
-    const source = Observable.of(1).publish();
+    const source = of(1).pipe(publish()) as ConnectableObservable<number>;
     expect(typeof (<any> source)._subscribe === 'function').to.be.true;
     expect(typeof (<any> source).getSubject === 'function').to.be.true;
     expect(typeof source.connect === 'function').to.be.true;
@@ -32,7 +31,7 @@ describe('Observable.prototype.publish', () => {
   it('should do nothing if connect is not called, despite subscriptions', () => {
     const source = cold('--1-2---3-4--5-|');
     const sourceSubs: string[] = [];
-    const published = source.publish();
+    const published = source.pipe(publish());
     const expected =    '-';
 
     expectObservable(published).toBe(expected);
@@ -42,7 +41,7 @@ describe('Observable.prototype.publish', () => {
   it('should multicast the same values to multiple observers', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^           !';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-1-2-3----4-|';
     const subscriber2 = hot('    b|       ').mergeMapTo(published);
@@ -63,12 +62,12 @@ describe('Observable.prototype.publish', () => {
     const sourceSubs =     ['^           !',
                             '    ^       !',
                             '        ^   !'];
-    const published = source.publish(x => x.zip(x, (a, b) => (parseInt(a) + parseInt(b)).toString()));
-    const subscriber1 = hot('a|           ').mergeMapTo(published);
+    const published = source.pipe(publish(x => x.pipe(zip(x, (a, b) => (parseInt(a) + parseInt(b)).toString()))));
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
     const expected1   =     '-2-4-6----8-|';
-    const subscriber2 = hot('    b|       ').mergeMapTo(published);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
     const expected2   =     '    -6----8-|';
-    const subscriber3 = hot('        c|   ').mergeMapTo(published);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
     const expected3   =     '        --8-|';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -80,12 +79,12 @@ describe('Observable.prototype.publish', () => {
   it('should multicast an error from the source to multiple observers', () => {
     const source =     cold('-1-2-3----4-#');
     const sourceSubs =      '^           !';
-    const published = source.publish();
-    const subscriber1 = hot('a|           ').mergeMapTo(published);
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
     const expected1   =     '-1-2-3----4-#';
-    const subscriber2 = hot('    b|       ').mergeMapTo(published);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
     const expected2   =     '    -3----4-#';
-    const subscriber3 = hot('        c|   ').mergeMapTo(published);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
     const expected3   =     '        --4-#';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -100,13 +99,13 @@ describe('Observable.prototype.publish', () => {
   'but is unsubscribed explicitly and early', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
     const unsub =           '         u   ';
-    const subscriber1 = hot('a|           ').mergeMapTo(published);
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
     const expected1   =     '-1-2-3----   ';
-    const subscriber2 = hot('    b|       ').mergeMapTo(published);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
     const expected2   =     '    -3----   ';
-    const subscriber3 = hot('        c|   ').mergeMapTo(published);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
     const expected3   =     '        --   ';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -115,10 +114,10 @@ describe('Observable.prototype.publish', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection: Rx.Subscription;
-    expectObservable(hot(unsub).do(() => {
+    let connection: Subscription;
+    expectObservable(hot(unsub).pipe(tap(() => {
       connection.unsubscribe();
-    })).toBe(unsub);
+    }))).toBe(unsub);
 
     connection = published.connect();
   });
@@ -126,14 +125,15 @@ describe('Observable.prototype.publish', () => {
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
-    const published = source
-      .mergeMap((x) => Observable.of(x))
-      .publish();
-    const subscriber1 = hot('a|           ').mergeMapTo(published);
+    const published = source.pipe(
+      mergeMap((x) => of(x)),
+      publish()
+    ) as ConnectableObservable<any>;
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
     const expected1   =     '-1-2-3----   ';
-    const subscriber2 = hot('    b|       ').mergeMapTo(published);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
     const expected2   =     '    -3----   ';
-    const subscriber3 = hot('        c|   ').mergeMapTo(published);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
     const expected3   =     '        --   ';
     const unsub =           '         u   ';
 
@@ -143,10 +143,10 @@ describe('Observable.prototype.publish', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection: Rx.Subscription;
-    expectObservable(hot(unsub).do(() => {
+    let connection: Subscription;
+    expectObservable(hot(unsub).pipe(tap(() => {
       connection.unsubscribe();
-    })).toBe(unsub);
+    }))).toBe(unsub);
 
     connection = published.connect();
   });
@@ -155,12 +155,15 @@ describe('Observable.prototype.publish', () => {
     it('should connect when first subscriber subscribes', () => {
       const source =     cold(   '-1-2-3----4-|');
       const sourceSubs =      '   ^           !';
-      const replayed = source.publish().refCount();
-      const subscriber1 = hot('   a|           ').mergeMapTo(replayed);
+      const replayed = source.pipe(
+        publish(),
+        refCount()
+      );
+      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(replayed));
       const expected1   =     '   -1-2-3----4-|';
-      const subscriber2 = hot('       b|       ').mergeMapTo(replayed);
+      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(replayed));
       const expected2   =     '       -3----4-|';
-      const subscriber3 = hot('           c|   ').mergeMapTo(replayed);
+      const subscriber3 = hot('           c|   ').pipe(mergeMapTo(replayed));
       const expected3   =     '           --4-|';
 
       expectObservable(subscriber1).toBe(expected1);
@@ -173,10 +176,10 @@ describe('Observable.prototype.publish', () => {
       const source =     cold(   '-1-2-3----4-|');
       const sourceSubs =      '   ^        !   ';
       const replayed = source.publish().refCount();
-      const subscriber1 = hot('   a|           ').mergeMapTo(replayed);
+      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(replayed));
       const unsub1 =          '          !     ';
       const expected1   =     '   -1-2-3--     ';
-      const subscriber2 = hot('       b|       ').mergeMapTo(replayed);
+      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(replayed));
       const unsub2 =          '            !   ';
       const expected2   =     '       -3----   ';
 
@@ -188,12 +191,16 @@ describe('Observable.prototype.publish', () => {
     it('should NOT be retryable', () => {
       const source =     cold('-1-2-3----4-#');
       const sourceSubs =      '^           !';
-      const published = source.publish().refCount().retry(3);
-      const subscriber1 = hot('a|           ').mergeMapTo(published);
+      const published = source.pipe(
+        publish(),
+        refCount(),
+        retry(3)
+      );
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
       const expected1   =     '-1-2-3----4-#';
-      const subscriber2 = hot('    b|       ').mergeMapTo(published);
+      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
       const expected2   =     '    -3----4-#';
-      const subscriber3 = hot('        c|   ').mergeMapTo(published);
+      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
       const expected3   =     '        --4-#';
 
       expectObservable(subscriber1).toBe(expected1);
@@ -205,12 +212,16 @@ describe('Observable.prototype.publish', () => {
     it('should NOT be repeatable', () => {
       const source =     cold('-1-2-3----4-|');
       const sourceSubs =      '^           !';
-      const published = source.publish().refCount().repeat(3);
-      const subscriber1 = hot('a|           ').mergeMapTo(published);
+      const published = source.pipe(
+        publish(),
+        refCount(),
+        repeat(3)
+      );
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
       const expected1   =     '-1-2-3----4-|';
-      const subscriber2 = hot('    b|       ').mergeMapTo(published);
+      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
       const expected2   =     '    -3----4-|';
-      const subscriber3 = hot('        c|   ').mergeMapTo(published);
+      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
       const expected3   =     '        --4-|';
 
       expectObservable(subscriber1).toBe(expected1);
@@ -234,7 +245,7 @@ describe('Observable.prototype.publish', () => {
       observer.complete();
     });
 
-    const connectable = source.publish();
+    const connectable = source.pipe(publish()) as ConnectableObservable<number>;
 
     connectable.subscribe((x) => {
       results1.push(x);
@@ -262,7 +273,7 @@ describe('Observable.prototype.publish', () => {
   it('should multicast an empty source', () => {
     const source = cold('|');
     const sourceSubs =  '(^!)';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
     const expected =    '|';
 
     expectObservable(published).toBe(expected);
@@ -274,7 +285,7 @@ describe('Observable.prototype.publish', () => {
   it('should multicast a never source', () => {
     const source = cold('-');
     const sourceSubs =  '^';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
     const expected =    '-';
 
     expectObservable(published).toBe(expected);
@@ -286,7 +297,7 @@ describe('Observable.prototype.publish', () => {
   it('should multicast a throw source', () => {
     const source = cold('#');
     const sourceSubs =  '(^!)';
-    const published = source.publish();
+    const published = source.pipe(publish()) as ConnectableObservable<string>;
     const expected =    '#';
 
     expectObservable(published).toBe(expected);
@@ -309,7 +320,7 @@ describe('Observable.prototype.publish', () => {
       observer.complete();
     });
 
-    const connectable = source.publish();
+    const connectable = source.pipe(publish()) as ConnectableObservable<number>;
 
     connectable.subscribe((x) => {
       results1.push(x);
@@ -332,44 +343,44 @@ describe('Observable.prototype.publish', () => {
 
   type('should infer the type', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
-    const result: Rx.ConnectableObservable<number> = source.publish();
+    const source = of<number>(1, 2, 3);
+    const result: ConnectableObservable<number> = source.pipe(publish()) as ConnectableObservable<number>;
     /* tslint:enable:no-unused-variable */
   });
 
   type('should infer the type with a selector', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
-    const result: Rx.Observable<number> = source.publish(s => s.map(x => x));
+    const source = of<number>(1, 2, 3);
+    const result: Observable<number> = source.pipe(publish(s => s.pipe(map(x => x))));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should infer the type with a type-changing selector', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
-    const result: Rx.Observable<string> = source.publish(s => s.map(x => x + '!'));
+    const source = of<number>(1, 2, 3);
+    const result: Observable<string> = source.pipe(publish(s => s.pipe(map(x => x + '!'))));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should infer the type for the pipeable operator', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
+    const source = of<number>(1, 2, 3);
     // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: Rx.ConnectableObservable<number> = Rx.operators.publish<number>()(source);
+    const result: ConnectableObservable<number> = publish<number>()(source);
     /* tslint:enable:no-unused-variable */
   });
 
   type('should infer the type for the pipeable operator with a selector', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
-    const result: Rx.Observable<number> = source.pipe(Rx.operators.publish(s => s.map(x => x)));
+    const source = of<number>(1, 2, 3);
+    const result: Observable<number> = source.pipe(publish(s => s.map(x => x)));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should infer the type for the pipeable operator with a type-changing selector', () => {
     /* tslint:disable:no-unused-variable */
-    const source = Rx.Observable.of<number>(1, 2, 3);
-    const result: Rx.Observable<string> = source.pipe(Rx.operators.publish(s => s.map(x => x + '!')));
+    const source = of<number>(1, 2, 3);
+    const result: Observable<string> = source.pipe(publish(s => s.pipe(map(x => x + '!'))));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -1,14 +1,13 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { reduce, mergeMap } from 'rxjs/operators';
+import { range, of, Observable } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
 
-const Observable = Rx.Observable;
-
 /** @test {reduce} */
-describe('Observable.prototype.reduce', () => {
+describe('reduce operator', () => {
   asDiagram('reduce((acc, curr) => acc + curr, 0)')('should reduce', () => {
     const values = {
       a: 1, b: 3, c: 5, x: 9
@@ -21,7 +20,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, 0)).toBe(expected, values);
+    expectObservable(e1.pipe(reduce(reduceFunction, 0))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -35,7 +34,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, seed)).toBe(expected, {x: seed + 'ab'});
+    expectObservable(e1.pipe(reduce(reduceFunction, seed))).toBe(expected, {x: seed + 'ab'});
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -48,7 +47,7 @@ describe('Observable.prototype.reduce', () => {
       x: 'undefined b c d e f g'
     };
 
-    const source = e1.reduce((acc: any, x: string) => acc + ' ' + x, undefined);
+    const source = e1.pipe(reduce((acc: any, x: string) => acc + ' ' + x, undefined));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -63,7 +62,7 @@ describe('Observable.prototype.reduce', () => {
       x: 'b c d e f g'
     };
 
-    const source = e1.reduce((acc: any, x: string) => acc + ' ' + x);
+    const source = e1.pipe(reduce((acc: any, x: string) => acc + ' ' + x));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -72,10 +71,10 @@ describe('Observable.prototype.reduce', () => {
   it('should reduce with index without seed', (done: MochaDone) => {
     const idx = [1, 2, 3, 4, 5];
 
-    Observable.range(0, 6).reduce((acc, value, index) => {
+    range(0, 6).pipe(reduce((acc, value, index) => {
       expect(idx.shift()).to.equal(index);
       return value;
-    }).subscribe(null, null, () => {
+    })).subscribe(null, null, () => {
       expect(idx).to.be.empty;
       done();
     });
@@ -84,10 +83,10 @@ describe('Observable.prototype.reduce', () => {
   it('should reduce with index with seed', (done: MochaDone) => {
     const idx = [0, 1, 2, 3, 4, 5];
 
-    Observable.range(0, 6).reduce((acc, value, index) => {
+    range(0, 6).pipe(reduce((acc, value, index) => {
       expect(idx.shift()).to.equal(index);
       return value;
-    }, -1).subscribe(null, null, () => {
+    }, -1)).subscribe(null, null, () => {
       expect(idx).to.be.empty;
       done();
     });
@@ -103,7 +102,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, expectedValue)).toBe(expected, {x: expectedValue});
+    expectObservable(e1.pipe(reduce(reduceFunction, expectedValue))).toBe(expected, {x: expectedValue});
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -116,7 +115,7 @@ describe('Observable.prototype.reduce', () => {
       throw 'error';
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -130,7 +129,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    const result = e1.reduce(reduceFunction);
+    const result = e1.pipe(reduce(reduceFunction));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -146,10 +145,11 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .reduce(reduceFunction)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      reduce(reduceFunction),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -165,7 +165,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, expectedValue)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction, expectedValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -179,7 +179,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, expectedValue)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction, expectedValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -193,7 +193,7 @@ describe('Observable.prototype.reduce', () => {
       throw 'error';
     };
 
-    expectObservable(e1.reduce(reduceFunction, seed)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction, seed))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -207,7 +207,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, seed)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction, seed))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -221,7 +221,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction, seed)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction, seed))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -234,7 +234,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -247,7 +247,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -260,7 +260,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -273,7 +273,7 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -286,22 +286,22 @@ describe('Observable.prototype.reduce', () => {
       return o + x;
     };
 
-    expectObservable(e1.reduce(reduceFunction)).toBe(expected);
+    expectObservable(e1.pipe(reduce(reduceFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   type('should accept array typed reducers', () => {
-    let a: Rx.Observable<{ a: number; b: string }>;
-    a.reduce((acc, value) => acc.concat(value), []);
+    let a: Observable<{ a: number; b: string }>;
+    a.pipe(reduce((acc, value) => acc.concat(value), []));
   });
 
   type('should accept T typed reducers', () => {
-    let a: Rx.Observable<{ a: number; b: string }>;
-    const reduced = a.reduce((acc, value) => {
+    let a: Observable<{ a: number; b: string }>;
+    const reduced = a.pipe(reduce((acc, value) => {
       value.a = acc.a;
       value.b = acc.b;
       return acc;
-    });
+    }));
 
     reduced.subscribe(r => {
       r.a.toExponential();
@@ -310,10 +310,10 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept T typed reducers when T is an array', () => {
-    let a: Rx.Observable<number[]>;
-    const reduced = a.reduce((acc, value) => {
+    let a: Observable<number[]>;
+    const reduced = a.pipe(reduce((acc, value) => {
       return acc.concat(value);
-    }, []);
+    }, []));
 
     reduced.subscribe(rs => {
       rs[0].toExponential();
@@ -321,11 +321,11 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept R typed reduces when R is an array of T', () => {
-    let a: Rx.Observable<number>;
-    const reduced = a.reduce((acc, value) => {
+    let a: Observable<number>;
+    const reduced = a.pipe(reduce((acc, value) => {
       acc.push(value);
       return acc;
-    }, []);
+    }, []));
 
     reduced.subscribe(rs => {
       rs[0].toExponential();
@@ -333,12 +333,12 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept R typed reducers when R is assignable to T', () => {
-    let a: Rx.Observable<{ a?: number; b?: string }>;
-    const reduced = a.reduce((acc, value) => {
+    let a: Observable<{ a?: number; b?: string }>;
+    const reduced = a.pipe(reduce((acc, value) => {
       value.a = acc.a;
       value.b = acc.b;
       return acc;
-    }, {} as { a?: number; b?: string });
+    }, {} as { a?: number; b?: string }));
 
     reduced.subscribe(r => {
       r.a.toExponential();
@@ -347,16 +347,16 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept R typed reducers when R is not assignable to T', () => {
-    let a: Rx.Observable<{ a: number; b: string }>;
+    let a: Observable<{ a: number; b: string }>;
     const seed = {
       as: [1],
       bs: ['a']
     };
-    const reduced = a.reduce((acc, value) => {
+    const reduced = a.pipe(reduce((acc, value: {a: number, b: string}) => {
       acc.as.push(value.a);
       acc.bs.push(value.b);
       return acc;
-    }, seed);
+    }, seed));
 
     reduced.subscribe(r => {
       r.as[0].toExponential();
@@ -365,12 +365,12 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept R typed reducers and reduce to type R', () => {
-    let a: Rx.Observable<{ a: number; b: string }>;
-    const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
+    let a: Observable<{ a: number; b: string }>;
+    const reduced = a.pipe(reduce<{ a?: number; b?: string }>((acc, value) => {
       value.a = acc.a;
       value.b = acc.b;
       return acc;
-    }, {});
+    }, {}));
 
     reduced.subscribe(r => {
       r.a.toExponential();
@@ -379,12 +379,12 @@ describe('Observable.prototype.reduce', () => {
   });
 
   type('should accept array of R typed reducers and reduce to array of R', () => {
-    let a: Rx.Observable<number>;
-    const reduced = a.reduce((acc, cur) => {
+    let a: Observable<number>;
+    const reduced = a.pipe(reduce((acc, cur) => {
       console.log(acc);
       acc.push(cur.toString());
       return acc;
-    }, [] as string[]);
+    }, [] as string[]));
 
     reduced.subscribe(rs => {
       rs[0].toLowerCase();

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -1,14 +1,15 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { repeat, mergeMap, map, multicast, refCount } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of, Subject } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {repeat} */
-describe('Observable.prototype.repeat', () => {
+describe('repeat operator', () => {
   asDiagram('repeat(3)')('should resubscribe count number of times', () => {
     const e1 =   cold('--a--b--|                ');
     const subs =     ['^       !                ',
@@ -16,7 +17,7 @@ describe('Observable.prototype.repeat', () => {
                     '                ^       !'];
     const expected =  '--a--b----a--b----a--b--|';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -28,7 +29,7 @@ describe('Observable.prototype.repeat', () => {
                     '                        ^       !'];
     const expected =  '--a--b----a--b----a--b----a--b--|';
 
-    expectObservable(e1.repeat(2).repeat(2)).toBe(expected);
+    expectObservable(e1.pipe(repeat(2), repeat(2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -37,7 +38,7 @@ describe('Observable.prototype.repeat', () => {
     const subs: string[] = [];
     const expected = '|';
 
-    expectObservable(e1.repeat(0)).toBe(expected);
+    expectObservable(e1.pipe(repeat(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -46,7 +47,7 @@ describe('Observable.prototype.repeat', () => {
     const subs =     '^       !';
     const expected = '--a--b--|';
 
-    expectObservable(e1.repeat(1)).toBe(expected);
+    expectObservable(e1.pipe(repeat(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -57,7 +58,7 @@ describe('Observable.prototype.repeat', () => {
     const unsub =    '              !';
     const expected = '--a--b----a--b-';
 
-    expectObservable(e1.repeat(10), unsub).toBe(expected);
+    expectObservable(e1.pipe(repeat(10)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -72,7 +73,7 @@ describe('Observable.prototype.repeat', () => {
     const unsub =    '                                            !';
     const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
-    expectObservable(e1.repeat(), unsub).toBe(expected);
+    expectObservable(e1.pipe(repeat()), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -87,10 +88,11 @@ describe('Observable.prototype.repeat', () => {
     const unsub =    '                                            !';
     const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .repeat()
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      repeat(),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -107,7 +109,7 @@ describe('Observable.prototype.repeat', () => {
     const unsub =    '                                            !';
     const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
-    expectObservable(e1.repeat(-1), unsub).toBe(expected);
+    expectObservable(e1.pipe(repeat(-1)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -116,7 +118,7 @@ describe('Observable.prototype.repeat', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -126,7 +128,7 @@ describe('Observable.prototype.repeat', () => {
     const subs =     '^                             !';
     const expected = '-';
 
-    expectObservable(e1.repeat(3), unsub).toBe(expected);
+    expectObservable(e1.pipe(repeat(3)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -135,7 +137,7 @@ describe('Observable.prototype.repeat', () => {
     const subs: string[] = [];
     const expected = '|';
 
-    expectObservable(e1.repeat(0)).toBe(expected);
+    expectObservable(e1.pipe(repeat(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -144,7 +146,7 @@ describe('Observable.prototype.repeat', () => {
     const subs: string[] = [];
     const expected = '|';
 
-    expectObservable(e1.repeat(0)).toBe(expected);
+    expectObservable(e1.pipe(repeat(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -153,7 +155,7 @@ describe('Observable.prototype.repeat', () => {
     const subs =     ['^       '];
     const expected =  '--a--b--';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -162,7 +164,7 @@ describe('Observable.prototype.repeat', () => {
     const e1subs =  ['(^!)', '(^!)', '(^!)'];
     const expected = '|';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -173,7 +175,7 @@ describe('Observable.prototype.repeat', () => {
                    '        ^   !'];
     const expected = '------------|';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -182,7 +184,7 @@ describe('Observable.prototype.repeat', () => {
     const subs: string[] = [];
     const expected = '|';
 
-    expectObservable(e1.repeat(0)).toBe(expected);
+    expectObservable(e1.pipe(repeat(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -191,7 +193,7 @@ describe('Observable.prototype.repeat', () => {
     const subs =     '^       !';
     const expected = '--a--b--#';
 
-    expectObservable(e1.repeat(2)).toBe(expected);
+    expectObservable(e1.pipe(repeat(2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -200,7 +202,7 @@ describe('Observable.prototype.repeat', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.repeat(3)).toBe(expected);
+    expectObservable(e1.pipe(repeat(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -209,34 +211,34 @@ describe('Observable.prototype.repeat', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.repeat()).toBe(expected);
+    expectObservable(e1.pipe(repeat())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   it('should raise error after first emit succeed', () => {
     let repeated = false;
 
-    const e1 = cold('--a--|').map((x: string) => {
+    const e1 = cold('--a--|').pipe(map((x: string) => {
       if (repeated) {
         throw 'error';
       } else {
         repeated = true;
         return x;
       }
-    });
+    }));
     const expected = '--a----#';
 
-    expectObservable(e1.repeat(2)).toBe(expected);
+    expectObservable(e1.pipe(repeat(2))).toBe(expected);
   });
 
   it('should repeat a synchronous source (multicasted and refCounted) multiple times', (done: MochaDone) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    Observable.of(1, 2, 3)
-      .multicast(() => new Rx.Subject<number>())
-      .refCount()
-      .repeat(5)
-      .subscribe(
+    of(1, 2, 3).pipe(
+      multicast(() => new Subject<number>()),
+      refCount(),
+      repeat(5)
+    ).subscribe(
         (x: number) => { expect(x).to.equal(expected.shift()); },
         (x) => {
           done(new Error('should not be called'));

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { retry, map, take, mergeMap, concat, multicast, refCount } from 'rxjs/operators';
+import { Observable, Observer, of, throwError, Subject } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {retry} */
-describe('Observable.prototype.retry', () => {
+describe('retry operator', () => {
   asDiagram('retry(2)')('should handle a basic source that emits next then errors, count=3', () => {
     const source = cold('--1-2-3-#');
     const subs =       ['^       !                ',
@@ -15,7 +14,7 @@ describe('Observable.prototype.retry', () => {
                       '                ^       !'];
     const expected =    '--1-2-3---1-2-3---1-2-3-#';
 
-    const result = source.retry(2);
+    const result = source.pipe(retry(2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -24,19 +23,19 @@ describe('Observable.prototype.retry', () => {
   it('should retry a number of times, without error, then complete', (done: MochaDone) => {
     let errors = 0;
     const retries = 2;
-    Observable.create((observer: Rx.Observer<number>) => {
+    Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    })
-      .map((x: any) => {
+    }).pipe(
+      map((x: any) => {
         if (++errors < retries) {
           throw 'bad';
         }
         errors = 0;
         return x;
-      })
-      .retry(retries)
-      .subscribe(
+      }),
+      retry(retries)
+    ).subscribe(
         (x: number) => {
           expect(x).to.equal(42);
         },
@@ -48,16 +47,16 @@ describe('Observable.prototype.retry', () => {
   it('should retry a number of times, then call error handler', (done: MochaDone) => {
     let errors = 0;
     const retries = 2;
-    Observable.create((observer: Rx.Observer<number>) => {
+    Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    })
-      .map((x: any) => {
+    }).pipe(
+      map((x: any) => {
         errors += 1;
         throw 'bad';
-      })
-      .retry(retries - 1)
-      .subscribe(
+      }),
+      retry(retries - 1)
+    ).subscribe(
         (x: number) => {
           expect(x).to.equal(42);
         },
@@ -72,20 +71,20 @@ describe('Observable.prototype.retry', () => {
   it('should retry until successful completion', (done: MochaDone) => {
     let errors = 0;
     const retries = 10;
-    Observable.create((observer: Rx.Observer<number>) => {
+    Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    })
-      .map((x: any) => {
+    }).pipe(
+      map((x: any) => {
         if (++errors < retries) {
           throw 'bad';
         }
         errors = 0;
         return x;
-      })
-      .retry()
-      .take(retries)
-      .subscribe(
+      }),
+      retry(),
+      take(retries)
+    ).subscribe(
         (x: number) => {
           expect(x).to.equal(42);
         },
@@ -99,7 +98,7 @@ describe('Observable.prototype.retry', () => {
     const subs =        '(^!)';
     const expected =    '|';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -110,7 +109,7 @@ describe('Observable.prototype.retry', () => {
     const subs =        '^';
     const expected =    '-';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -121,7 +120,7 @@ describe('Observable.prototype.retry', () => {
     const unsub =       '                                     !';
     const expected =    '--------------------------------------';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result, unsub).toBe(expected);
   });
@@ -131,7 +130,7 @@ describe('Observable.prototype.retry', () => {
     const subs =               '^            !';
     const expected =           '---3--4--5---|';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -142,7 +141,7 @@ describe('Observable.prototype.retry', () => {
     const subs =               '^            ';
     const expected =           '---3--4--5---';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -158,7 +157,7 @@ describe('Observable.prototype.retry', () => {
                       '                                ^    !'];
     const expected =    '--1-2-3---1-2-3---1-2-3---1-2-3---1-2-';
 
-    const result = source.retry();
+    const result = source.pipe(retry());
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -172,7 +171,7 @@ describe('Observable.prototype.retry', () => {
                       '        ^    !           '];
     const expected =    '--1-2-3---1-2-';
 
-    const result = source.retry(3);
+    const result = source.pipe(retry(3));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -185,10 +184,11 @@ describe('Observable.prototype.retry', () => {
     const expected =    '--1-2-3---1-2-';
     const unsub =       '             !           ';
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .retry(100)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      retry(100),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -197,11 +197,12 @@ describe('Observable.prototype.retry', () => {
   it('should retry a synchronous source (multicasted and refCounted) multiple times', (done: MochaDone) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    Observable.of(1, 2, 3).concat(Observable.throw('bad!'))
-      .multicast(() => new Rx.Subject())
-      .refCount()
-      .retry(4)
-      .subscribe(
+    of(1, 2, 3).pipe(
+      concat(throwError('bad!')),
+      multicast(() => new Subject()),
+      refCount(),
+      retry(4)
+    ).subscribe(
         (x: number) => { expect(x).to.equal(expected.shift()); },
         (err: any) => {
           expect(err).to.equal('bad!');

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { retryWhen, map, mergeMap, takeUntil, flatMap } from 'rxjs/operators';
+import { of, EMPTY } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {retryWhen} */
-describe('Observable.prototype.retryWhen', () => {
+describe('retryWhen operator', () => {
   asDiagram('retryWhen')('should handle a source with eventual error using a hot notifier', () => {
     const source =  cold('-1--2--#');
     const subs =        ['^      !                     ',
@@ -16,7 +15,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = hot('-------------r------------r-|');
     const expected =     '-1--2---------1--2---------1|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -30,7 +29,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = hot('-----------r-------r---------#');
     const expected =     '-1--2-------1--2----1--2-----#';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -40,22 +39,22 @@ describe('Observable.prototype.retryWhen', () => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
-    Observable.of(1, 2, 3)
-      .map((n: number) => {
+    of(1, 2, 3).pipe(
+      map((n: number) => {
         if (n === 3) {
           throw 'bad';
         }
         return n;
-      })
-      .retryWhen((errors: any) => errors.map((x: any) => {
+      }),
+      retryWhen((errors: any) => errors.pipe(map((x: any) => {
           expect(x).to.equal('bad');
           if (retried) {
             throw new Error('done');
           }
           retried = true;
           return x;
-      }))
-      .subscribe((x: any) => {
+      })))
+    ).subscribe((x: any) => {
         expect(x).to.equal(expected[i++]);
       },
       (err: any) => {
@@ -66,15 +65,15 @@ describe('Observable.prototype.retryWhen', () => {
 
   it('should retry when notified and complete on returned completion', (done: MochaDone) => {
     const expected = [1, 2, 1, 2];
-    Observable.of(1, 2, 3)
-      .map((n: number) => {
+    of(1, 2, 3).pipe(
+      map((n: number) => {
         if (n === 3) {
           throw 'bad';
         }
         return n;
-      })
-      .retryWhen((errors: any) => Observable.empty())
-      .subscribe((n: number) => {
+      }),
+      retryWhen((errors: any) => EMPTY)
+    ).subscribe((n: number) => {
         expect(n).to.equal(expected.shift());
       }, (err: any) => {
         done(new Error('should not be called'));
@@ -89,7 +88,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('|');
     const expected =      '|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -101,7 +100,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('-');
     const expected =      '|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -114,7 +113,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('|');
     const expected =      '-';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -127,7 +126,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('-');
     const expected =      '-';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -138,7 +137,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('|');
     const expected =      '|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
   });
@@ -148,7 +147,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold('-');
     const expected =      '-';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
   });
@@ -159,7 +158,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold(           '-');
     const expected =      '--a--b--c---------------------------------';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -170,7 +169,7 @@ describe('Observable.prototype.retryWhen', () => {
     const subs =        '^          !';
     const expected =    '--a--b--c--#';
 
-    const result = source.retryWhen(<any>(() => { throw 'bad!'; }));
+    const result = source.pipe(retryWhen(<any>(() => { throw 'bad!'; })));
 
     expectObservable(result).toBe(expected, undefined, 'bad!');
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -183,7 +182,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold(           '|');
     const expected =      '--a--b--c--|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -195,7 +194,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold(           '|');
     const expected =      '--a--b--c--|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -207,7 +206,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold(           '|');
     const expected =      '--a--b--c---';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -219,7 +218,7 @@ describe('Observable.prototype.retryWhen', () => {
     const notifier = cold(         '|');
     const expected =      '---b--c--|';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -233,13 +232,15 @@ describe('Observable.prototype.retryWhen', () => {
     const nsubs =        '       ^           !';
     const expected =     '-1--2---      -5---|';
 
-    const result = source
-      .map((x: string) => {
+    const result = source.pipe(
+      map((x: string) => {
         if (x === '3') {
           throw 'error';
         }
         return x;
-      }).retryWhen(() => notifier);
+      }),
+      retryWhen(() => notifier)
+    );
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(ssubs);
@@ -256,7 +257,7 @@ describe('Observable.prototype.retryWhen', () => {
     const nsubs =        '       ^            !       ';
     const expected =     '-1--2-----1--2----1--       ';
 
-    const result = source.retryWhen((errors: any) => notifier);
+    const result = source.pipe(retryWhen((errors: any) => notifier));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -273,10 +274,11 @@ describe('Observable.prototype.retryWhen', () => {
     const expected =     '-1--2-----1--2----1--       ';
     const unsub =        '                    !       ';
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .retryWhen((errors: any) => notifier)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      retryWhen((errors: any) => notifier),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -292,14 +294,14 @@ describe('Observable.prototype.retryWhen', () => {
     const expected =    '-1--2---1--2---1--2--#';
 
     let invoked = 0;
-    const result = source.retryWhen((errors: any) =>
-      errors.map((err: any) => {
+    const result = source.pipe(retryWhen((errors: any) =>
+      errors.pipe(map((err: any) => {
         if (++invoked === 3) {
           throw 'error';
         } else {
           return 'x';
         }
-      }));
+      }))));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -314,17 +316,17 @@ describe('Observable.prototype.retryWhen', () => {
     const expected =    '-1--2---1--2---1--2--|';
 
     let invoked = 0;
-    const result = source.retryWhen((errors: any) => errors
-        .map(() => 'x')
-        .takeUntil(
-          errors.flatMap(() => {
+    const result = source.pipe(retryWhen((errors: any) => errors.pipe(
+        map(() => 'x'),
+        takeUntil(
+          errors.pipe(flatMap(() => {
             if (++invoked < 3) {
-              return Observable.empty();
+              return EMPTY;
             } else {
-              return Observable.of('stop!');
+              return of('stop!');
             }
-          })
-      ));
+          }))
+      ))));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/sample-spec.ts
+++ b/spec/operators/sample-spec.ts
@@ -1,14 +1,12 @@
-import * as Rx from 'rxjs/Rx';
 import { expect } from 'chai';
-
 import { hot, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { sample, mergeMap } from 'rxjs/operators';
+import { Subject, of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {sample} */
-describe('Observable.prototype.sample', () => {
+describe('sample operator', () => {
   asDiagram('sample')('should get samples when the notifier emits', () => {
     const e1 =   hot('---a----b---c----------d-----|   ');
     const e1subs =   '^                            !   ';
@@ -16,7 +14,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^                            !   ';
     const expected = '-----a----------c----------d-|   ';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -28,18 +26,18 @@ describe('Observable.prototype.sample', () => {
     const e2subs =         '^            !';
     const expected =       '-------------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should behave properly when notified by the same observable as the source (issue #2075)', () => {
-    const item$ = new Rx.Subject<number>();
+    const item$ = new Subject<number>();
     const results: number[] = [];
 
-    item$
-      .sample(item$)
-      .subscribe(value => results.push(value));
+    item$.pipe(
+      sample(item$)
+    ).subscribe(value => results.push(value));
 
     item$.next(1);
     item$.next(2);
@@ -55,7 +53,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =         '^            !';
     const expected =       '-------------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -67,7 +65,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =         '^          !';
     const expected =       '-----------b------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -79,7 +77,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^       !                         ';
     const expected = '------a---------------------------';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -91,7 +89,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^       !                         ';
     const expected = '------a--------------------------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -104,7 +102,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =         '^             !                        ';
     const expected =       '-----b---------                        ';
 
-    expectObservable(e1.sample(e2), unsub).toBe(expected);
+    expectObservable(e1.pipe(sample(e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -117,10 +115,11 @@ describe('Observable.prototype.sample', () => {
     const expected =       '-----b---------                        ';
     const unsub =          '              !                        ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .sample(e2)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      sample(e2),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -134,7 +133,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^                                 !  ';
     const expected = '------a--------c------c----e------|  ';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -146,7 +145,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =         '^                 !                    ';
     const expected =       '-----b----------d-#                    ';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -158,7 +157,7 @@ describe('Observable.prototype.sample', () => {
     const e1subs =   '(^!)';
     const e2subs =   '(^!)';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -170,7 +169,7 @@ describe('Observable.prototype.sample', () => {
     const e1subs =   '(^!)';
     const e2subs =   '(^!)';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -182,7 +181,7 @@ describe('Observable.prototype.sample', () => {
     const e1subs =   '^   !';
     const e2subs =   '^   !';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -194,7 +193,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^             !';
     const expected = '-';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -206,7 +205,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '^                    !';
     const expected = '-----------b---------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -218,7 +217,7 @@ describe('Observable.prototype.sample', () => {
     const e2subs =   '(^!)';
     const expected = '---------------------|';
 
-    expectObservable(e1.sample(e2)).toBe(expected);
+    expectObservable(e1.pipe(sample(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });

--- a/spec/operators/sampleTime-spec.ts
+++ b/spec/operators/sampleTime-spec.ts
@@ -1,20 +1,21 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { sampleTime, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {sampleTime} */
-describe('Observable.prototype.sampleTime', () => {
+describe('sampleTime operator', () => {
   asDiagram('sampleTime(70)')('should get samples on a delay', () => {
     const e1 =   hot('a---b-c---------d--e---f-g-h--|');
     const e1subs =   '^                             !';
     const expected = '-------c-------------e------h-|';
     // timer          -------!------!------!------!--
 
-    expectObservable(e1.sampleTime(70, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(70, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -24,7 +25,7 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '-----------c----------------|';
     // timer              -----------!----------!---------
 
-    expectObservable(e1.sampleTime(110, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -34,7 +35,7 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '-----------c----------c-----|';
     // timer              -----------!----------!---------
 
-    expectObservable(e1.sampleTime(110, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -44,7 +45,7 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '----------------------b-----|';
     // timer              -----------!----------!---------
 
-    expectObservable(e1.sampleTime(110, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -54,7 +55,7 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '-----------c------#';
     // timer              -----------!----------!---------
 
-    expectObservable(e1.sampleTime(110, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -65,7 +66,7 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '-----------c-----            ';
     // timer              -----------!----------!---------
 
-    expectObservable(e1.sampleTime(110, rxTestScheduler), unsub).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -76,10 +77,11 @@ describe('Observable.prototype.sampleTime', () => {
     const expected =       '-----------c-----            ';
     const unsub =          '                !            ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .sampleTime(110, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      sampleTime(110, rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -90,7 +92,7 @@ describe('Observable.prototype.sampleTime', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.sampleTime(60, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -99,7 +101,7 @@ describe('Observable.prototype.sampleTime', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.sampleTime(60, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -108,7 +110,7 @@ describe('Observable.prototype.sampleTime', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.sampleTime(60, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,14 +1,15 @@
 import * as _ from 'lodash';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+import { sequenceEqual } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
 
 declare const type: Function;
 declare const asDiagram: Function;
-declare const rxTestScheduler: Rx.TestScheduler;
+declare const rxTestScheduler: TestScheduler;
 const booleans = { T: true, F: false };
 
 /** @test {sequenceEqual} */
-describe('Observable.prototype.sequenceEqual', () => {
+describe('sequenceEqual operator', () => {
   asDiagram('sequenceEqual(observable)')('should return true for two equal sequences', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--|');
     const s1subs =      '^                        !';
@@ -16,7 +17,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -28,7 +29,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 = cold('(abc|)');
     const expected = '(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
   });
@@ -38,7 +39,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 = cold('(abcdefg|)');
     const expected = '(T|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
   });
@@ -50,7 +51,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -64,7 +65,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -77,7 +78,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected =    '-----------#';
     const sub =         '^          !';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(sub);
@@ -90,7 +91,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected =    '-----------#';
     const sub =         '^          !';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(sub);
@@ -102,7 +103,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 =  cold('---a--b--c--|');
     const expected = '#'; // throw
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected);
   });
@@ -112,7 +113,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 =  cold('--a--b--c--|');
     const expected = '------------'; // never
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected);
   });
@@ -122,7 +123,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 =  cold('------------'); // never
     const expected = '------------'; // never
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected);
   });
@@ -133,7 +134,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected = '------(F|)';
     const subs =     '^     !';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(subs);
@@ -146,7 +147,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected = '------(F|)';
     const subs =     '^     !';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(subs);
@@ -158,7 +159,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 = cold('|');
     const expected = '-';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected);
   });
@@ -168,7 +169,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 = cold('-');
     const expected = '-';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected);
   });
@@ -181,12 +182,12 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected =    '-------------#';
 
     let i = 0;
-    const source = s1.sequenceEqual(s2, (a: any, b: any) => {
+    const source = s1.pipe(sequenceEqual(s2, (a: any, b: any) => {
       if (++i === 2) {
         throw new Error('shazbot');
       }
       return a.value === b.value;
-    });
+    }));
 
     const values: { [key: string]: any } = {
       a: null,
@@ -210,7 +211,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
 
-    const source = s1.sequenceEqual(s2, (a: any, b: any) => a.value === b.value);
+    const source = s1.pipe(sequenceEqual(s2, (a: any, b: any) => a.value === b.value));
 
     const values: { [key: string]: any } = {
       a: null,
@@ -234,7 +235,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^                      !';
     const expected =    '-----------------------(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -248,7 +249,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^         !';
     const expected =    '----------(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -262,7 +263,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^           !';
     const expected =    '------------(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -276,7 +277,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2subs =      '^           !';
     const expected =    '------------(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
 
     expectObservable(source).toBe(expected, booleans);
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
@@ -288,7 +289,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 =  cold('|');
     const expected = '(T|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
     expectObservable(source).toBe(expected, booleans);
   });
 
@@ -297,7 +298,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s2 =  cold('---a--|');
     const expected = '---(F|)';
 
-    const source = s1.sequenceEqual(s2);
+    const source = s1.pipe(sequenceEqual(s2));
     expectObservable(source).toBe(expected, booleans);
   });
 
@@ -311,8 +312,8 @@ describe('Observable.prototype.sequenceEqual', () => {
     const expected2 =    '                   ---------------------(T|)';
     const subs2 =        '                   ^                    !';
 
-    const test1 = s1.sequenceEqual(s2);
-    const test2 = s1.sequenceEqual(s3);
+    const test1 = s1.pipe(sequenceEqual(s2));
+    const test2 = s1.pipe(sequenceEqual(s3));
 
     expectObservable(test1).toBe(expected1, booleans);
     rxTestScheduler.schedule(() => expectObservable(test2).toBe(expected2, booleans), time(delay));

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -1,17 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { shareReplay, mergeMapTo, retry, take } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { Observable, interval, Operator, Observer } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {shareReplay} */
-describe('Observable.prototype.shareReplay', () => {
+describe('shareReplay operator', () => {
   it('should mirror a simple source Observable', () => {
     const source = cold('--1-2---3-4--5-|');
     const sourceSubs =  '^              !';
-    const published = source.shareReplay();
+    const published = source.pipe(shareReplay());
     const expected =    '--1-2---3-4--5-|';
 
     expectObservable(published).toBe(expected);
@@ -23,18 +24,18 @@ describe('Observable.prototype.shareReplay', () => {
     const source = new Observable(() => {
       subscribed = true;
     });
-    source.shareReplay();
+    source.pipe(shareReplay());
     expect(subscribed).to.be.false;
   });
 
   it('should multicast the same values to multiple observers, bufferSize=1', () => {
-    const source =     cold('-1-2-3----4-|'); const shared = source.shareReplay(1);
+    const source =     cold('-1-2-3----4-|'); const shared = source.pipe(shareReplay(1));
     const sourceSubs =      '^           !';
-    const subscriber1 = hot('a|           ').mergeMapTo(shared);
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-3----4-|';
-    const subscriber2 = hot('    b|       ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
     const expected2   =     '    23----4-|';
-    const subscriber3 = hot('        c|   ').mergeMapTo(shared);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
     const expected3   =     '        3-4-|';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -44,13 +45,13 @@ describe('Observable.prototype.shareReplay', () => {
   });
 
   it('should multicast the same values to multiple observers, bufferSize=2', () => {
-    const source =     cold('-1-2-----3------4-|'); const shared = source.shareReplay(2);
+    const source =     cold('-1-2-----3------4-|'); const shared = source.pipe(shareReplay(2));
     const sourceSubs =      '^                 !';
-    const subscriber1 = hot('a|                 ').mergeMapTo(shared);
+    const subscriber1 = hot('a|                 ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-----3------4-|';
-    const subscriber2 = hot('    b|             ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|             ').pipe(mergeMapTo(shared));
     const expected2   =     '    (12)-3------4-|';
-    const subscriber3 = hot('           c|       ').mergeMapTo(shared);
+    const subscriber3 = hot('           c|       ').pipe(mergeMapTo(shared));
     const expected3   =     '           (23)-4-|';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -60,13 +61,13 @@ describe('Observable.prototype.shareReplay', () => {
   });
 
   it('should multicast an error from the source to multiple observers', () => {
-    const source =     cold('-1-2-3----4-#'); const shared = source.shareReplay(1);
+    const source =     cold('-1-2-3----4-#'); const shared = source.pipe(shareReplay(1));
     const sourceSubs =      '^           !';
-    const subscriber1 = hot('a|           ').mergeMapTo(shared);
+    const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-3----4-#';
-    const subscriber2 = hot('    b|       ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
     const expected2   =     '    23----4-#';
-    const subscriber3 = hot('        c|   ').mergeMapTo(shared);
+    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
     const expected3   =     '        3-4-#';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -78,7 +79,7 @@ describe('Observable.prototype.shareReplay', () => {
   it('should multicast an empty source', () => {
     const source = cold('|');
     const sourceSubs =  '(^!)';
-    const shared = source.shareReplay(1);
+    const shared = source.pipe(shareReplay(1));
     const expected =    '|';
 
     expectObservable(shared).toBe(expected);
@@ -89,7 +90,7 @@ describe('Observable.prototype.shareReplay', () => {
     const source = cold('-');
     const sourceSubs =  '^';
 
-    const shared = source.shareReplay(1);
+    const shared = source.pipe(shareReplay(1));
     const expected =    '-';
 
     expectObservable(shared).toBe(expected);
@@ -99,7 +100,7 @@ describe('Observable.prototype.shareReplay', () => {
   it('should multicast a throw source', () => {
     const source = cold('#');
     const sourceSubs =  '(^!)';
-    const shared = source.shareReplay(1);
+    const shared = source.pipe(shareReplay(1));
     const expected =    '#';
 
     expectObservable(shared).toBe(expected);
@@ -108,13 +109,13 @@ describe('Observable.prototype.shareReplay', () => {
 
   it('should replay results to subsequent subscriptions if source completes, bufferSize=2', () => {
     const source =     cold('-1-2-----3-|        ');
-    const shared = source.shareReplay(2);
+    const shared = source.pipe(shareReplay(2));
     const sourceSubs =      '^          !        ';
-    const subscriber1 = hot('a|                  ').mergeMapTo(shared);
+    const subscriber1 = hot('a|                  ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-----3-|        ';
-    const subscriber2 = hot('    b|              ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|              ').pipe(mergeMapTo(shared));
     const expected2   =     '    (12)-3-|        ';
-    const subscriber3 = hot('               (c|) ').mergeMapTo(shared);
+    const subscriber3 = hot('               (c|) ').pipe(mergeMapTo(shared));
     const expected3   =     '               (23|)';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -125,13 +126,13 @@ describe('Observable.prototype.shareReplay', () => {
 
   it('should completely restart for subsequent subscriptions if source errors, bufferSize=2', () => {
     const source =     cold('-1-2-----3-#               ');
-    const shared = source.shareReplay(2);
+    const shared = source.pipe(shareReplay(2));
     const sourceSubs1 =     '^          !               ';
-    const subscriber1 = hot('a|                         ').mergeMapTo(shared);
+    const subscriber1 = hot('a|                         ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-----3-#               ';
-    const subscriber2 = hot('    b|                     ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|                     ').pipe(mergeMapTo(shared));
     const expected2   =     '    (12)-3-#               ';
-    const subscriber3 = hot('               (c|)        ').mergeMapTo(shared);
+    const subscriber3 = hot('               (c|)        ').pipe(mergeMapTo(shared));
     const expected3   =     '               -1-2-----3-#';
     const sourceSubs2 =     '               ^          !';
 
@@ -144,15 +145,15 @@ describe('Observable.prototype.shareReplay', () => {
   it('should be retryable, bufferSize=2', () => {
     const subs = [];
     const source =     cold('-1-2-----3-#                      ');
-    const shared = source.shareReplay(2).retry(1);
+    const shared = source.pipe(shareReplay(2), retry(1));
     subs.push(              '^          !                      ');
     subs.push(              '           ^          !           ');
     subs.push(              '                      ^          !');
-    const subscriber1 = hot('a|                                ').mergeMapTo(shared);
+    const subscriber1 = hot('a|                                ').pipe(mergeMapTo(shared));
     const expected1   =     '-1-2-----3--1-2-----3-#           ';
-    const subscriber2 = hot('    b|                            ').mergeMapTo(shared);
+    const subscriber2 = hot('    b|                            ').pipe(mergeMapTo(shared));
     const expected2   =     '    (12)-3--1-2-----3-#           ';
-    const subscriber3 = hot('               (c|)               ').mergeMapTo(shared);
+    const subscriber3 = hot('               (c|)               ').pipe(mergeMapTo(shared));
     const expected3   =     '               (12)-3--1-2-----3-#';
 
     expectObservable(subscriber1).toBe(expected1);
@@ -163,9 +164,10 @@ describe('Observable.prototype.shareReplay', () => {
 
   it('should not restart if refCount hits 0 due to unsubscriptions', () => {
     const results: number[] = [];
-    const source = Rx.Observable.interval(10, rxTestScheduler)
-      .take(10)
-      .shareReplay(1);
+    const source = interval(10, rxTestScheduler).pipe(
+      take(10),
+      shareReplay(1)
+    );
     const subs = source.subscribe(x => results.push(x));
     rxTestScheduler.schedule(() => subs.unsubscribe(), 35);
     rxTestScheduler.schedule(() => source.subscribe(x => results.push(x)), 54);
@@ -175,8 +177,8 @@ describe('Observable.prototype.shareReplay', () => {
   });
 
   it('should not break lift() composability', (done: MochaDone) => {
-    class MyCustomObservable<T> extends Rx.Observable<T> {
-      lift<R>(operator: Rx.Operator<T, R>): Rx.Observable<R> {
+    class MyCustomObservable<T> extends Observable<T> {
+      lift<R>(operator: Operator<T, R>): Observable<R> {
         const observable = new MyCustomObservable<R>();
         (<any>observable).source = this;
         (<any>observable).operator = operator;
@@ -184,12 +186,12 @@ describe('Observable.prototype.shareReplay', () => {
       }
     }
 
-    const result = new MyCustomObservable((observer: Rx.Observer<number>) => {
+    const result = new MyCustomObservable((observer: Observer<number>) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
       observer.complete();
-    }).shareReplay();
+    }).pipe(shareReplay());
 
     expect(result instanceof MyCustomObservable).to.be.true;
 

--- a/spec/operators/skip-spec.ts
+++ b/spec/operators/skip-spec.ts
@@ -1,18 +1,17 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { skip, mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {skip} */
-describe('Observable.prototype.skip', () => {
+describe('skip operator', () => {
   asDiagram('skip(3)')('should skip values before a total', () => {
     const source = hot('--a--b--c--d--e--|');
     const subs =       '^                !';
     const expected =   '-----------d--e--|';
 
-    expectObservable(source.skip(3)).toBe(expected);
+    expectObservable(source.pipe(skip(3))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -21,7 +20,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^                !';
     const expected =   '-----------------|';
 
-    expectObservable(source.skip(6)).toBe(expected);
+    expectObservable(source.pipe(skip(6))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -30,7 +29,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^                !';
     const expected =   '-----------------|';
 
-    expectObservable(source.skip(5)).toBe(expected);
+    expectObservable(source.pipe(skip(5))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -39,7 +38,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^                !';
     const expected =   '--a--b--c--d--e--|';
 
-    expectObservable(source.skip(0)).toBe(expected);
+    expectObservable(source.pipe(skip(0))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -49,7 +48,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^         !       ';
     const expected =   '--------c--       ';
 
-    expectObservable(source.skip(2), unsub).toBe(expected);
+    expectObservable(source.pipe(skip(2)), unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -59,10 +58,11 @@ describe('Observable.prototype.skip', () => {
     const expected =   '--------c--       ';
     const unsub =      '          !       ';
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .skip(2)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      skip(2),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -73,7 +73,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^             !';
     const expected =   '--------------#';
 
-    expectObservable(source.skip(6)).toBe(expected);
+    expectObservable(source.pipe(skip(6))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -82,7 +82,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^             !';
     const expected =   '--------------#';
 
-    expectObservable(source.skip(4)).toBe(expected);
+    expectObservable(source.pipe(skip(4))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -91,7 +91,7 @@ describe('Observable.prototype.skip', () => {
     const subs =       '^             !';
     const expected =   '-----------d--#';
 
-    expectObservable(source.skip(3)).toBe(expected);
+    expectObservable(source.pipe(skip(3))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -100,7 +100,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.skip(3)).toBe(expected);
+    expectObservable(e1.pipe(skip(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -109,7 +109,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.skip(3)).toBe(expected);
+    expectObservable(e1.pipe(skip(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -118,7 +118,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '^         ';
     const expected = '-----b--c-';
 
-    expectObservable(e1.skip(1)).toBe(expected);
+    expectObservable(e1.pipe(skip(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -127,7 +127,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '^         ';
     const expected = '----------';
 
-    expectObservable(e1.skip(6)).toBe(expected);
+    expectObservable(e1.pipe(skip(6))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -136,7 +136,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '^         ';
     const expected = '----------';
 
-    expectObservable(e1.skip(3)).toBe(expected);
+    expectObservable(e1.pipe(skip(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -145,7 +145,7 @@ describe('Observable.prototype.skip', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.skip(3)).toBe(expected);
+    expectObservable(e1.pipe(skip(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { skipLast, mergeMap } from 'rxjs/operators';
+import { range, ArgumentOutOfRangeError, of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {takeLast} */
-describe('Observable.prototype.skipLast', () => {
+describe('skipLast operator', () => {
   asDiagram('skipLast(2)')('should skip two values of an observable with many values', () => {
     const e1 =  cold('--a-----b----c---d--|');
     const e1subs =   '^                   !';
     const expected = '-------------a---b--|';
 
-    expectObservable(e1.skipLast(2)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -22,7 +21,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^                   !';
     const expected = '-----------------a--|';
 
-    expectObservable(e1.skipLast(3)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -31,7 +30,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^                   !';
     const expected = '--------------------|';
 
-    expectObservable(e1.skipLast(5)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(5))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -40,7 +39,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^                   !';
     const expected = '--------------------|';
 
-    expectObservable(e1.skipLast(4)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(4))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -49,7 +48,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^                   !';
     const expected = '--a-----b----c---d--|';
 
-    expectObservable(e1.skipLast(0)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -58,7 +57,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.skipLast(42)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -67,7 +66,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.skipLast(42)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -76,7 +75,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '^  !   ';
     const expected = '---|   ';
 
-    expectObservable(e1.skipLast(1)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -85,7 +84,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =      '^              !';
     const expected =    '--------b---c--|';
 
-    expectObservable(e1.skipLast(1)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -94,7 +93,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =      '^    !';
     const expected =    '-----|';
 
-    expectObservable(e1.skipLast(42)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -103,7 +102,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =    '^   !';
     const expected =  '----#';
 
-    expectObservable(e1.skipLast(42)).toBe(expected, null, 'too bad');
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected, null, 'too bad');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -112,7 +111,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =    '^        !';
     const expected =  '---------#';
 
-    expectObservable(e1.skipLast(42)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -122,7 +121,7 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =    '^        !            ';
     const expected =  '----------            ';
 
-    expectObservable(e1.skipLast(42), unsub).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -131,13 +130,13 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.skipLast(42)).toBe(expected);
+    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   it('should throw if total is less than zero', () => {
-    expect(() => { Observable.range(0, 10).skipLast(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    expect(() => { range(0, 10).pipe(skipLast(-1)); })
+      .to.throw(ArgumentOutOfRangeError);
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
@@ -146,10 +145,11 @@ describe('Observable.prototype.skipLast', () => {
     const e1subs =    '^        !            ';
     const expected =  '----------            ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .skipLast(42)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      skipLast(42),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { skipWhile, mergeMap, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {skipWhile} */
-describe('Observable.prototype.skipWhile', () => {
+describe('skipWhile operator', () => {
   asDiagram('skipWhile(x => x < 4)')('should skip all elements until predicate is false', () => {
     const source = hot('-1-^2--3--4--5--6--|');
     const sourceSubs =    '^               !';
@@ -17,7 +16,7 @@ describe('Observable.prototype.skipWhile', () => {
       return +v < 4;
     };
 
-    expectObservable(source.skipWhile(predicate)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -26,7 +25,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =    '^               !';
     const expected =      '----------------|';
 
-    expectObservable(source.skipWhile(() => true)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -35,7 +34,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =    '^               !';
     const expected =      '----------------|';
 
-    expectObservable(source.skipWhile((): any => { return {}; })).toBe(expected);
+    expectObservable(source.pipe(skipWhile((): any => { return {}; }))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -44,7 +43,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =    '^               !';
     const expected =      '-2--3--4--5--6--|';
 
-    expectObservable(source.skipWhile(() => false)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => false))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -53,7 +52,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =    '^               !';
     const expected =      '-2--3--4--5--6--|';
 
-    expectObservable(source.skipWhile(() => undefined)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => undefined))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -66,7 +65,7 @@ describe('Observable.prototype.skipWhile', () => {
       return +v < 5;
     };
 
-    expectObservable(source.skipWhile(predicate)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -79,7 +78,7 @@ describe('Observable.prototype.skipWhile', () => {
       return index < 2;
     };
 
-    expectObservable(source.skipWhile(predicate)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -93,7 +92,7 @@ describe('Observable.prototype.skipWhile', () => {
       return index < 1;
     };
 
-    expectObservable(source.skipWhile(predicate), unsub).toBe(expected);
+    expectObservable(source.pipe(skipWhile(predicate)), unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -107,10 +106,11 @@ describe('Observable.prototype.skipWhile', () => {
       return index < 1;
     };
 
-    const result = source
-      .mergeMap(function (x) { return Observable.of(x); })
-      .skipWhile(predicate)
-      .mergeMap(function (x) { return Observable.of(x); });
+    const result = source.pipe(
+      mergeMap(function (x) { return of(x); }),
+      skipWhile(predicate),
+      mergeMap(function (x) { return of(x); })
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -125,7 +125,7 @@ describe('Observable.prototype.skipWhile', () => {
       return v !== 'd';
     };
 
-    expectObservable(source.skipWhile(predicate)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -141,9 +141,12 @@ describe('Observable.prototype.skipWhile', () => {
     };
 
     expectObservable(
-      source.skipWhile(predicate).do(null, null, () => {
-        expect(invoked).to.equal(3);
-      })
+      source.pipe(
+        skipWhile(predicate),
+        tap(null, null, () => {
+          expect(invoked).to.equal(3);
+        })
+      )
     ).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
@@ -161,7 +164,7 @@ describe('Observable.prototype.skipWhile', () => {
       return v !== 'f';
     };
 
-    expectObservable(source.skipWhile(predicate)).toBe(expected, undefined, new Error('nom d\'une pipe !'));
+    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected, undefined, new Error('nom d\'une pipe !'));
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
@@ -170,7 +173,7 @@ describe('Observable.prototype.skipWhile', () => {
     const subs =        '(^!)';
     const expected =    '|';
 
-    expectObservable(source.skipWhile(() => true)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -179,7 +182,7 @@ describe('Observable.prototype.skipWhile', () => {
     const subs =        '^';
     const expected =    '-';
 
-    expectObservable(source.skipWhile(() => true)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -188,7 +191,7 @@ describe('Observable.prototype.skipWhile', () => {
     const subs =        '(^!)';
     const expected =    '#';
 
-    expectObservable(source.skipWhile(() => true)).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 });

--- a/spec/operators/startWith-spec.ts
+++ b/spec/operators/startWith-spec.ts
@@ -1,13 +1,14 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { startWith, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {startWith} */
-describe('Observable.prototype.startWith', () => {
+describe('startWith operator', () => {
   const defaultStartValue = 'x';
 
   asDiagram('startWith(s)')('should prepend to a cold Observable', () => {
@@ -15,7 +16,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^           !';
     const expected = 's--a--b--c--|';
 
-    expectObservable(e1.startWith('s')).toBe(expected);
+    expectObservable(e1.pipe(startWith('s'))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -24,7 +25,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^    !';
     const expected = 'x-a--|';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -33,7 +34,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^     ';
     const expected = 'x---a-';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -42,7 +43,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^';
     const expected = 'x-';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -51,7 +52,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^  !';
     const expected = 'x--|';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -60,7 +61,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '(^!)';
     const expected = '(x|)';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -69,7 +70,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '(^!)';
     const expected = '(xa|)';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -78,7 +79,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^       !';
     const expected = '(yz)-a--|';
 
-    expectObservable(e1.startWith('y', 'z')).toBe(expected);
+    expectObservable(e1.pipe(startWith('y', 'z'))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -87,7 +88,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^ !';
     const expected = 'x-#';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected, defaultStartValue);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected, defaultStartValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -96,7 +97,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '(^!)';
     const expected = '(x#)';
 
-    expectObservable(e1.startWith(defaultStartValue)).toBe(expected, defaultStartValue);
+    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected, defaultStartValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -107,7 +108,7 @@ describe('Observable.prototype.startWith', () => {
     const expected = 's--a--b---';
     const values = { s: 's', a: 'a', b: 'b' };
 
-    const result = e1.startWith('s', rxTestScheduler);
+    const result = e1.pipe(startWith('s', rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -120,10 +121,11 @@ describe('Observable.prototype.startWith', () => {
     const unsub =    '         !        ';
     const values = { s: 's', a: 'a', b: 'b' };
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .startWith('s', rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      startWith('s', rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -134,7 +136,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^  !';
     const expected = '-a-|';
 
-    expectObservable(e1.startWith(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(startWith(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -143,7 +145,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^    !';
     const expected = 'x-a--|';
 
-    expectObservable(e1.startWith(defaultStartValue, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(startWith(defaultStartValue, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -152,7 +154,7 @@ describe('Observable.prototype.startWith', () => {
     const e1subs =   '^       !';
     const expected = '(yz)-a--|';
 
-    expectObservable(e1.startWith('y', 'z', rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(startWith('y', 'z', rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/subscribeOn-spec.ts
+++ b/spec/operators/subscribeOn-spec.ts
@@ -1,19 +1,20 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { subscribeOn, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {subscribeOn} */
-describe('Observable.prototype.subscribeOn', () => {
+describe('subscribeOn operator', () => {
   asDiagram('subscribeOn(scheduler)')('should subscribe on specified scheduler', () => {
     const e1 =   hot('--a--b--|');
     const expected = '--a--b--|';
     const sub =      '^       !';
 
-    expectObservable(e1.subscribeOn(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -22,7 +23,7 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected = '-----b--|';
     const sub =      '   ^    !';
 
-    expectObservable(e1.subscribeOn(rxTestScheduler, 30)).toBe(expected);
+    expectObservable(e1.pipe(subscribeOn(rxTestScheduler, 30))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -31,7 +32,7 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected = '--a--#';
     const sub =      '^    !';
 
-    expectObservable(e1.subscribeOn(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -40,7 +41,7 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected = '----|';
     const sub =      '^   !';
 
-    expectObservable(e1.subscribeOn(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -49,7 +50,7 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected = '----';
     const sub =      '^   ';
 
-    expectObservable(e1.subscribeOn(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -59,7 +60,7 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected =  '--a--    ';
     const unsub =     '    !    ';
 
-    const result = e1.subscribeOn(rxTestScheduler);
+    const result = e1.pipe(subscribeOn(rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
@@ -71,10 +72,11 @@ describe('Observable.prototype.subscribeOn', () => {
     const expected =  '--a--    ';
     const unsub =     '    !    ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .subscribeOn(rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      subscribeOn(rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { switchMap, mergeMap } from 'rxjs/operators';
+import { switchMap, mergeMap, map } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
@@ -15,7 +15,7 @@ describe('switchMap', () => {
     const expected =  '--x-x-x-y-yz-z-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.pipe(switchMap(x => e2.map(i => i * +x)));
+    const result = e1.pipe(switchMap(x => e2.pipe(map(i => i * +x))));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -78,9 +78,9 @@ describe('switchMapTo', () => {
   });
 
   it('should switch a synchronous many outer to a synchronous many inner', (done) => {
-    const a = Observable.of(1, 2, 3);
+    const a = of(1, 2, 3);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
-    a.pipe(switchMapTo(Observable.of('a', 'b', 'c'))).subscribe((x) => {
+    a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, done);
   });
@@ -88,7 +88,7 @@ describe('switchMapTo', () => {
   it('should unsub inner observables', () => {
     let unsubbed = 0;
 
-    Observable.of('a', 'b').pipe(switchMapTo(
+    of('a', 'b').pipe(switchMapTo(
       new Observable<string>((subscriber) => {
         subscriber.complete();
         return () => {
@@ -257,7 +257,7 @@ describe('switchMapTo', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.pipe(switchMapTo(Observable.of('foo')))).toBe(expected);
+    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -266,7 +266,7 @@ describe('switchMapTo', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.pipe(switchMapTo(Observable.of('foo')))).toBe(expected);
+    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -275,7 +275,7 @@ describe('switchMapTo', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.pipe(switchMapTo(Observable.of('foo')))).toBe(expected);
+    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { takeLast, mergeMap } from 'rxjs/operators';
+import { range, ArgumentOutOfRangeError, of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {takeLast} */
-describe('Observable.prototype.takeLast', () => {
+describe('takeLast operator', () => {
   asDiagram('takeLast(2)')('should take two values of an observable with many values', () => {
     const e1 =  cold('--a-----b----c---d--|    ');
     const e1subs =   '^                   !    ';
     const expected = '--------------------(cd|)';
 
-    expectObservable(e1.takeLast(2)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -22,7 +21,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '^                   !    ';
     const expected = '--------------------(bcd|)';
 
-    expectObservable(e1.takeLast(3)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(3))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -31,7 +30,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '^                   !    ';
     const expected = '--------------------(abcd|)';
 
-    expectObservable(e1.takeLast(5)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(5))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -40,7 +39,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '^                   !    ';
     const expected = '--------------------(abcd|)';
 
-    expectObservable(e1.takeLast(4)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(4))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -48,7 +47,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1 =  cold('--a-----b----c---d--|');
     const expected = '|';
 
-    expectObservable(e1.takeLast(0)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(0))).toBe(expected);
   });
 
   it('should work with empty', () => {
@@ -56,7 +55,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.takeLast(42)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -65,7 +64,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.takeLast(42)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -74,7 +73,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs: string[] = []; // Don't subscribe at all
     const expected =    '|';
 
-    expectObservable(e1.takeLast(0)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(0))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -83,7 +82,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '^  !   ';
     const expected = '---(a|)';
 
-    expectObservable(e1.takeLast(1)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -92,7 +91,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =      '^              !   ';
     const expected =    '---------------(d|)';
 
-    expectObservable(e1.takeLast(1)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(1))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -101,7 +100,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =      '^    !';
     const expected =    '-----|';
 
-    expectObservable(e1.takeLast(42)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -110,7 +109,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =    '^   !';
     const expected =  '----#';
 
-    expectObservable(e1.takeLast(42)).toBe(expected, null, 'too bad');
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected, null, 'too bad');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -119,7 +118,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =    '^        !';
     const expected =  '---------#';
 
-    expectObservable(e1.takeLast(42)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -129,7 +128,7 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =    '^        !            ';
     const expected =  '----------            ';
 
-    expectObservable(e1.takeLast(42), unsub).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -138,13 +137,13 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.takeLast(42)).toBe(expected);
+    expectObservable(e1.pipe(takeLast(42))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   it('should throw if total is less than zero', () => {
-    expect(() => { Observable.range(0, 10).takeLast(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    expect(() => { range(0, 10).pipe(takeLast(-1)); })
+      .to.throw(ArgumentOutOfRangeError);
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
@@ -153,10 +152,11 @@ describe('Observable.prototype.takeLast', () => {
     const e1subs =    '^        !            ';
     const expected =  '----------            ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .takeLast(42)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      takeLast(42),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/takeUntil-spec.ts
+++ b/spec/operators/takeUntil-spec.ts
@@ -1,12 +1,11 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { takeUntil, mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {takeUntil} */
-describe('Observable.prototype.takeUntil', () => {
+describe('takeUntil operator', () => {
   asDiagram('takeUntil')('should take values until notifier emits', () => {
     const e1 =     hot('--a--b--c--d--e--f--g--|');
     const e1subs =     '^            !          ';
@@ -14,7 +13,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^            !          ';
     const expected =   '--a--b--c--d-|          ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -26,7 +25,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^            !          ';
     const expected =   '--a--b--c--d-#          ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -38,7 +37,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^            !          ';
     const expected =   '--a--b--c--d--e--f--g--|';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -50,17 +49,17 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^                      !';
     const expected =   '--a--b--c--d--e--f--g--|';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should complete without subscribing to the source when notifier synchronously emits', () => {
     const e1 =   hot('----a--|');
-    const e2 =  Observable.of(0);
+    const e2 =  of(0);
     const expected = '(|)     ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe([]);
   });
 
@@ -72,7 +71,7 @@ describe('Observable.prototype.takeUntil', () => {
     const unsub =      '       !                ';
     const expected =   '--a--b--                ';
 
-    expectObservable(e1.takeUntil(e2), unsub).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -84,7 +83,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^ !';
     const expected =   '--|';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -96,7 +95,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^ !';
     const expected =   '--#';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -108,7 +107,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^ !';
     const expected =   '---';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -120,7 +119,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^';
     const expected =   '-';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -132,7 +131,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^ !     ';
     const expected =   '--|     ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -144,7 +143,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =     '^             !     ';
     const expected =   '--a--b--c--d--#     ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -156,7 +155,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -168,7 +167,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =   '^ !     ';
     const expected = '--|     ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -180,7 +179,7 @@ describe('Observable.prototype.takeUntil', () => {
     const e2subs =   '^    !     ';
     const expected = '--a--|     ';
 
-    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectObservable(e1.pipe(takeUntil(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -193,10 +192,11 @@ describe('Observable.prototype.takeUntil', () => {
     const unsub =      '       !                ';
     const expected =   '--a--b--                ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .takeUntil(e2)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      takeUntil(e2),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -1,18 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { takeWhile, tap, mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
 /** @test {takeWhile} */
-describe('Observable.prototype.takeWhile', () => {
+describe('takeWhile operator', () => {
   asDiagram('takeWhile(x => x < 4)')('should take all elements until predicate is false', () => {
     const source = hot('-1-^2--3--4--5--6--|');
     const sourceSubs =    '^      !         ';
     const expected =      '-2--3--|         ';
 
-    const result = source.takeWhile((v: any) => +v < 4);
+    const result = source.pipe(takeWhile((v: any) => +v < 4));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -23,7 +23,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^             !';
     const expected =   '--b--c--d--e--|';
 
-    expectObservable(e1.takeWhile(() => true)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => true))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -32,7 +32,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^             !';
     const expected =   '--b--c--d--e--|';
 
-    expectObservable(e1.takeWhile(<any>(() => { return {}; }))).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(<any>(() => { return {}; })))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -41,7 +41,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^ !            ';
     const expected =   '--|            ';
 
-    expectObservable(e1.takeWhile(() => false)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => false))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -50,7 +50,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^ !            ';
     const expected =   '--|            ';
 
-    expectObservable(e1.takeWhile(() => null)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => null))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -63,7 +63,7 @@ describe('Observable.prototype.takeWhile', () => {
       return value !== 'd';
     }
 
-    expectObservable(e1.takeWhile(predicate)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -72,7 +72,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^             ';
     const expected =   '--b--c--d--e--';
 
-    expectObservable(e1.takeWhile(() => true)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => true))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -81,7 +81,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const result = e1.takeWhile(() => true);
+    const result = e1.pipe(takeWhile(() => true));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -92,7 +92,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^            !';
     const expected =   '-------------|';
 
-    expectObservable(e1.takeWhile(() => true)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => true))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -101,7 +101,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const result = e1.takeWhile(() => true);
+    const result = e1.pipe(takeWhile(() => true));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -116,7 +116,7 @@ describe('Observable.prototype.takeWhile', () => {
       return index < 2;
     }
 
-    expectObservable(e1.takeWhile(predicate)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -125,7 +125,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^             !';
     const expected =   '--b--c--d--e--#';
 
-    expectObservable(e1.takeWhile(() => true)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => true))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -134,7 +134,7 @@ describe('Observable.prototype.takeWhile', () => {
     const subs =        '(^!)';
     const expected =    '#';
 
-    expectObservable(source.takeWhile(() => true)).toBe(expected);
+    expectObservable(source.pipe(takeWhile(() => true))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -149,9 +149,12 @@ describe('Observable.prototype.takeWhile', () => {
       return value !== 'd';
     }
 
-    const source = e1.takeWhile(predicate).do(null, null, () => {
-      expect(invoked).to.equal(3);
-    });
+    const source = e1.pipe(
+      takeWhile(predicate),
+      tap(null, null, () => {
+        expect(invoked).to.equal(3);
+      })
+    );
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
@@ -165,7 +168,7 @@ describe('Observable.prototype.takeWhile', () => {
       throw 'error';
     }
 
-    expectObservable(e1.takeWhile(<any>predicate)).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(<any>predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -179,7 +182,7 @@ describe('Observable.prototype.takeWhile', () => {
       return value !== 'd';
     }
 
-    expectObservable(e1.takeWhile(predicate), unsub).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(predicate)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -193,10 +196,11 @@ describe('Observable.prototype.takeWhile', () => {
       return value !== 'd';
     }
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .takeWhile(predicate)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      takeWhile(predicate),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -1,14 +1,13 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { throttle, mergeMap, mapTo } from 'rxjs/operators';
+import { of, concat, timer, Observable } from 'rxjs';
 
 declare const type: Function;
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {throttle} */
-describe('Observable.prototype.throttle', () =>  {
+describe('throttle operator', () =>  {
   asDiagram('throttle')('should immediately emit the first value in each time window', () =>  {
     const e1 =   hot('-a-xy-----b--x--cxxx-|');
     const e1subs =   '^                    !';
@@ -18,7 +17,7 @@ describe('Observable.prototype.throttle', () =>  {
                    '                ^   ! '];
     const expected = '-a--------b-----c----|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -34,7 +33,7 @@ describe('Observable.prototype.throttle', () =>  {
                    '                ^   ! '];
     const expected = '-a--------b-----c----|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -50,7 +49,7 @@ describe('Observable.prototype.throttle', () =>  {
                    '                ^   ! '];
     const expected = '-a--------b-----c----|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -65,7 +64,7 @@ describe('Observable.prototype.throttle', () =>  {
     const e2subs =   ' ^            !               ';
     const expected = '-a-------------               ';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -80,10 +79,11 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '-a-------------               ';
     const unsub =    '              !               ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .throttle(() =>  e2)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      throttle(() =>  e2),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -101,7 +101,7 @@ describe('Observable.prototype.throttle', () =>  {
                    '                        ^!'];
     const expected = 'a-----a-----a-----a-----a|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -114,7 +114,7 @@ describe('Observable.prototype.throttle', () =>  {
     const e2 =  cold('|');
     const expected = 'abcdefabcdefabcdefabcdefa|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -127,7 +127,7 @@ describe('Observable.prototype.throttle', () =>  {
     const e2subs =   '    ^                        !';
     const expected = '----a------------------------|';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -141,7 +141,7 @@ describe('Observable.prototype.throttle', () =>  {
     const e2subs =   '    ^                        !';
     const expected = '----a------------------------#';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -155,7 +155,7 @@ describe('Observable.prototype.throttle', () =>  {
     const e2subs =   '    (^!)                      ';
     const expected = '----(a#)                      ';
 
-    const result = e1.throttle(() =>  e2);
+    const result = e1.pipe(throttle(() =>  e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -178,7 +178,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = 'a-----a---a-------a--a|   ';
 
     let i = 0;
-    const result = e1.throttle(() =>  e2[i++]);
+    const result = e1.pipe(throttle(() =>  e2[i++]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -199,7 +199,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = 'a-----a---a------#        ';
 
     let i = 0;
-    const result = e1.throttle(() =>  e2[i++]);
+    const result = e1.pipe(throttle(() =>  e2[i++]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -218,12 +218,12 @@ describe('Observable.prototype.throttle', () =>  {
     const exp =      '---x-----x-----x-----(e#)';
 
     let i = 0;
-    const result = s1.throttle(() => {
+    const result = s1.pipe(throttle(() => {
       if (i++ === 3) {
         throw new Error('lol');
       }
       return n1;
-    });
+    }));
     expectObservable(result).toBe(exp, undefined, new Error('lol'));
     expectSubscriptions(s1.subscriptions).toBe(s1Subs);
     expectSubscriptions(n1.subscriptions).toBe(n1Subs);
@@ -235,7 +235,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '-----|';
     function durationSelector() { return cold('-----|'); }
 
-    expectObservable(e1.throttle(durationSelector)).toBe(expected);
+    expectObservable(e1.pipe(throttle(durationSelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -245,7 +245,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '-----#';
     function durationSelector() { return cold('-----|'); }
 
-    expectObservable(e1.throttle(durationSelector)).toBe(expected);
+    expectObservable(e1.pipe(throttle(durationSelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -255,7 +255,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '|';
     function durationSelector() { return cold('-----|'); }
 
-    expectObservable(e1.throttle(durationSelector)).toBe(expected);
+    expectObservable(e1.pipe(throttle(durationSelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -265,7 +265,7 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '-';
     function durationSelector() { return cold('-----|'); }
 
-    expectObservable(e1.throttle(durationSelector)).toBe(expected);
+    expectObservable(e1.pipe(throttle(durationSelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -275,21 +275,21 @@ describe('Observable.prototype.throttle', () =>  {
     const expected = '#';
     function durationSelector() { return cold('-----|'); }
 
-    expectObservable(e1.throttle(durationSelector)).toBe(expected);
+    expectObservable(e1.pipe(throttle(durationSelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
   it('should throttle by promise resolves', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
-      Observable.timer(10).mapTo(2),
-      Observable.timer(10).mapTo(3),
-      Observable.timer(50).mapTo(4)
+    const e1 = concat(of(1),
+      timer(10).pipe(mapTo(2)),
+      timer(10).pipe(mapTo(3)),
+      timer(50).pipe(mapTo(4))
     );
     const expected = [1, 2, 3, 4];
 
-    e1.throttle(() =>  {
+    e1.pipe(throttle(() =>  {
       return new Promise((resolve: any) => { resolve(42); });
-    }).subscribe(
+    })).subscribe(
       (x: number) => {
         expect(x).to.equal(expected.shift()); },
       () =>  {
@@ -303,21 +303,21 @@ describe('Observable.prototype.throttle', () =>  {
   });
 
   it('should raise error when promise rejects', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
-      Observable.timer(10).mapTo(2),
-      Observable.timer(10).mapTo(3),
-      Observable.timer(50).mapTo(4)
+    const e1 = concat(of(1),
+      timer(10).pipe(mapTo(2)),
+      timer(10).pipe(mapTo(3)),
+      timer(50).pipe(mapTo(4))
     );
     const expected = [1, 2, 3];
     const error = new Error('error');
 
-    e1.throttle((x: number) => {
+    e1.pipe(throttle((x: number) => {
       if (x === 3) {
         return new Promise((resolve: any, reject: any) => { reject(error); });
       } else {
         return new Promise((resolve: any) => { resolve(42); });
       }
-    }).subscribe(
+    })).subscribe(
       (x: number) => {
         expect(x).to.equal(expected.shift()); },
       (err: any) => {
@@ -333,17 +333,17 @@ describe('Observable.prototype.throttle', () =>  {
 
   type('should support selectors of the same type', () => {
     /* tslint:disable:no-unused-variable */
-    let o: Rx.Observable<number>;
-    let s: Rx.Observable<number>;
-    let r: Rx.Observable<number> = o.throttle((n) => s);
+    let o: Observable<number>;
+    let s: Observable<number>;
+    let r: Observable<number> = o.pipe(throttle((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support selectors of a different type', () => {
     /* tslint:disable:no-unused-variable */
-    let o: Rx.Observable<number>;
-    let s: Rx.Observable<string>;
-    let r: Rx.Observable<number> = o.throttle((n) => s);
+    let o: Observable<number>;
+    let s: Observable<string>;
+    let r: Observable<number> = o.pipe(throttle((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 
@@ -360,7 +360,7 @@ describe('Observable.prototype.throttle', () =>  {
                        '                      ^   !'];
       const expected = '-a---y----b---x---x---x---|';
 
-      const result = e1.throttle(() =>  e2, { leading: true, trailing: true });
+      const result = e1.pipe(throttle(() =>  e2, { leading: true, trailing: true }));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -374,7 +374,7 @@ describe('Observable.prototype.throttle', () =>  {
       const n1Subs = ['  ^                  !'];
       const exp =     '--x------------------|';
 
-      const result = s1.throttle(() => n1, { leading: true, trailing: true });
+      const result = s1.pipe(throttle(() => n1, { leading: true, trailing: true }));
       expectObservable(result).toBe(exp);
       expectSubscriptions(s1.subscriptions).toBe(s1Subs);
       expectSubscriptions(n1.subscriptions).toBe(n1Subs);
@@ -394,7 +394,7 @@ describe('Observable.prototype.throttle', () =>  {
                        '                      ^   !'];
       const expected = '-a---y----b---x---x---x---|';
 
-      const result = e1.throttle(() =>  e2, { leading: true, trailing: true });
+      const result = e1.pipe(throttle(() =>  e2, { leading: true, trailing: true }));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -408,7 +408,7 @@ describe('Observable.prototype.throttle', () =>  {
       const n1Subs = ['  ^                  !'];
       const exp =     '--x------------------|';
 
-      const result = s1.throttle(() => n1, { leading: true, trailing: true });
+      const result = s1.pipe(throttle(() => n1, { leading: true, trailing: true }));
       expectObservable(result).toBe(exp);
       expectSubscriptions(s1.subscriptions).toBe(s1Subs);
       expectSubscriptions(n1.subscriptions).toBe(n1Subs);

--- a/spec/operators/timeInterval-spec.ts
+++ b/spec/operators/timeInterval-spec.ts
@@ -1,21 +1,25 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { timeInterval, map, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
+import { TimeInterval } from 'rxjs/internal/operators/timeInterval';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {timeInterval} */
-describe('Observable.prototype.timeInterval', () => {
+describe('timeInterval operator', () => {
   asDiagram('timeInterval')('should record the time interval between source elements', () => {
     const e1 = hot('--a--^b-c-----d--e--|');
     const e1subs =      '^              !';
     const expected =    '-w-x-----y--z--|';
     const expectedValue = { w: 10, x: 20, y: 60, z: 30 };
 
-    const result = (<any>e1).timeInterval(rxTestScheduler)
-      .map((x: any) => x.interval);
+    const result = (<any>e1).pipe(
+      timeInterval(rxTestScheduler),
+      map((x: any) => x.interval)
+    );
 
     expectObservable(result).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -27,13 +31,13 @@ describe('Observable.prototype.timeInterval', () => {
     const expected =    '-w--x----y---z--|';
 
     const expectedValue = {
-      w: new Rx.TimeInterval('b', 10),
-      x: new Rx.TimeInterval('c', 30),
-      y: new Rx.TimeInterval('d', 50),
-      z: new Rx.TimeInterval('e', 40)
+      w: new TimeInterval('b', 10),
+      x: new TimeInterval('c', 30),
+      y: new TimeInterval('d', 50),
+      z: new TimeInterval('e', 40)
     };
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -42,7 +46,7 @@ describe('Observable.prototype.timeInterval', () => {
     const e1subs =   '^        !';
     const expected = '---------|';
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -51,7 +55,7 @@ describe('Observable.prototype.timeInterval', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -61,11 +65,11 @@ describe('Observable.prototype.timeInterval', () => {
     const expected = '-y--z--';
 
     const expectedValue = {
-      y: new Rx.TimeInterval('a', 10),
-      z: new Rx.TimeInterval('b', 30)
+      y: new TimeInterval('a', 10),
+      z: new TimeInterval('b', 30)
     };
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -76,11 +80,11 @@ describe('Observable.prototype.timeInterval', () => {
     const expected = '-y--z---           ';
 
     const expectedValue = {
-      y: new Rx.TimeInterval('a', 10),
-      z: new Rx.TimeInterval('b', 30)
+      y: new TimeInterval('a', 10),
+      z: new TimeInterval('b', 30)
     };
 
-    const result = (<any>e1).timeInterval(rxTestScheduler);
+    const result = (<any>e1).pipe(timeInterval(rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -93,14 +97,15 @@ describe('Observable.prototype.timeInterval', () => {
     const unsub =    '       !           ';
 
     const expectedValue = {
-      y: new Rx.TimeInterval('a', 10),
-      z: new Rx.TimeInterval('b', 30)
+      y: new TimeInterval('a', 10),
+      z: new TimeInterval('b', 30)
     };
 
-    const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
-      .timeInterval(rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = (<any>e1).pipe(
+      mergeMap((x: string) => of(x)),
+      timeInterval(rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -111,7 +116,7 @@ describe('Observable.prototype.timeInterval', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -120,7 +125,7 @@ describe('Observable.prototype.timeInterval', () => {
     const e1subs =   '^  !';
     const expected = '---#';
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -130,11 +135,11 @@ describe('Observable.prototype.timeInterval', () => {
     const expected = '-y--z--#';
 
     const expectedValue = {
-      y: new Rx.TimeInterval('a', 10),
-      z: new Rx.TimeInterval('b', 30)
+      y: new TimeInterval('a', 10),
+      z: new TimeInterval('b', 30)
     };
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -143,7 +148,7 @@ describe('Observable.prototype.timeInterval', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable((<any>e1).timeInterval(rxTestScheduler)).toBe(expected);
+    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/timeoutWith-spec.ts
+++ b/spec/operators/timeoutWith-spec.ts
@@ -1,13 +1,13 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { timeoutWith, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
-declare const rxTestScheduler: Rx.TestScheduler;
-
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {timeoutWith} */
-describe('Observable.prototype.timeoutWith', () => {
+describe('timeoutWith operator', () => {
   asDiagram('timeoutWith(50)')('should timeout after a specified period then subscribe to the passed observable', () => {
     const e1 =  cold('-------a--b--|');
     const e1subs =   '^    !        ';
@@ -15,7 +15,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '     ^     !  ';
     const expected = '-----x-y-z-|  ';
 
-    const result = e1.timeoutWith(50, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(50, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -29,7 +29,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '          ^          !';
     const expected = '------------x--y--z--|';
 
-    const result = e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -44,7 +44,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =     '           ^    !  ';
     const expected =   '---a---b----x-y-|  ';
 
-    const result = e1.timeoutWith(40, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(40, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -59,7 +59,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const expected =   '---a---b----x--    ';
     const unsub =      '              !    ';
 
-    const result = e1.timeoutWith(40, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(40, e2, rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -74,10 +74,11 @@ describe('Observable.prototype.timeoutWith', () => {
     const expected =   '---a---b----x--    ';
     const unsub =      '              !    ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .timeoutWith(40, e2, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      timeoutWith(40, e2, rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -92,10 +93,11 @@ describe('Observable.prototype.timeoutWith', () => {
     const expected = '---a--           ';
     const unsub =    '     !           ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .timeoutWith(50, e2, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      timeoutWith(50, e2, rxTestScheduler),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -110,7 +112,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '          ^        !';
     const expected = '--------------x----|';
 
-    const result = e1.timeoutWith(100, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(100, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -125,7 +127,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '         ^           ';
     const expected = '--a--b----           ';
 
-    const result = e1.timeoutWith(40, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(40, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -140,7 +142,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '          ^        !';
     const expected = '--------------x----|';
 
-    const result = e1.timeoutWith(100, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(100, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -155,7 +157,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '          ^        ';
     const expected = '--------------x----';
 
-    const result = e1.timeoutWith(100, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(100, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -169,7 +171,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs: string[] = [];
     const expected = '-----|';
 
-    const result = e1.timeoutWith(100, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(100, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -183,7 +185,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs: string[] = [];
     const expected = '-----#';
 
-    const result = e1.timeoutWith(100, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(100, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -197,7 +199,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs: string[] = [];
     const expected = '--a--b--c--d--e--|';
 
-    const result = e1.timeoutWith(50, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(50, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -211,7 +213,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '       ^    !     ';
     const expected = '--a--b---z--|     ';
 
-    const result = e1.timeoutWith(new Date(rxTestScheduler.now() + 70), e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(new Date(rxTestScheduler.now() + 70), e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -227,7 +229,7 @@ describe('Observable.prototype.timeoutWith', () => {
 
     const timeoutValue = new Date(Date.now() + (expected.length + 2) * 10);
 
-    const result = e1.timeoutWith(timeoutValue, e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(timeoutValue, e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -241,7 +243,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs: string[] = [];
     const expected = '---a---#';
 
-    const result = e1.timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -256,7 +258,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e2subs =   '          ^             ';
     const expected = '---a---b---             ';
 
-    const result = e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler);
+    const result = e1.pipe(timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -283,7 +285,7 @@ describe('Observable.prototype.timeoutWith', () => {
           return source.subscribe(timeoutSubscriber);
         }
       })
-      .timeoutWith(40, e2, rxTestScheduler);
+      .pipe(timeoutWith(40, e2, rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/timestamp-spec.ts
+++ b/spec/operators/timestamp-spec.ts
@@ -1,21 +1,25 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { timestamp, map, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of } from 'rxjs';
+import { Timestamp } from 'rxjs/internal/operators/timestamp';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {timestamp} */
-describe('Observable.prototype.timestamp', () => {
+describe('timestamp operator', () => {
   asDiagram('timestamp')('should record the time stamp per each source elements', () => {
     const e1 =   hot('-b-c-----d--e--|');
     const e1subs =   '^              !';
     const expected = '-w-x-----y--z--|';
     const expectedValue = { w: 10, x: 30, y: 90, z: 120 };
 
-    const result = e1.timestamp(rxTestScheduler)
-      .map(x => x.timestamp);
+    const result = e1.pipe(
+      timestamp(rxTestScheduler),
+      map(x => x.timestamp)
+    );
 
     expectObservable(result).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -27,13 +31,13 @@ describe('Observable.prototype.timestamp', () => {
     const expected =    '-w--x----y---z--|';
 
     const expectedValue = {
-      w: new Rx.Timestamp('b', 10),
-      x: new Rx.Timestamp('c', 40),
-      y: new Rx.Timestamp('d', 90),
-      z: new Rx.Timestamp('e', 130)
+      w: new Timestamp('b', 10),
+      x: new Timestamp('c', 40),
+      y: new Timestamp('d', 90),
+      z: new Timestamp('e', 130)
     };
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -42,7 +46,7 @@ describe('Observable.prototype.timestamp', () => {
     const e1subs =   '^        !';
     const expected = '---------|';
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -51,7 +55,7 @@ describe('Observable.prototype.timestamp', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -61,11 +65,11 @@ describe('Observable.prototype.timestamp', () => {
     const expected = '-y--z--';
 
     const expectedValue = {
-      y: new Rx.Timestamp('a', 10),
-      z: new Rx.Timestamp('b', 40)
+      y: new Timestamp('a', 10),
+      z: new Timestamp('b', 40)
     };
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -76,11 +80,11 @@ describe('Observable.prototype.timestamp', () => {
     const expected = '-y--z---           ';
 
     const expectedValue = {
-      y: new Rx.Timestamp('a', 10),
-      z: new Rx.Timestamp('b', 40)
+      y: new Timestamp('a', 10),
+      z: new Timestamp('b', 40)
     };
 
-    const result = e1.timestamp(rxTestScheduler);
+    const result = e1.pipe(timestamp(rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -93,14 +97,15 @@ describe('Observable.prototype.timestamp', () => {
     const unsub =    '       !           ';
 
     const expectedValue = {
-      y: new Rx.Timestamp('a', 10),
-      z: new Rx.Timestamp('b', 40)
+      y: new Timestamp('a', 10),
+      z: new Timestamp('b', 40)
     };
 
-    const result = e1
-      .mergeMap(x => Observable.of(x))
-      .timestamp(rxTestScheduler)
-      .mergeMap(x => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      timestamp(rxTestScheduler),
+      mergeMap(x => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -111,7 +116,7 @@ describe('Observable.prototype.timestamp', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -120,7 +125,7 @@ describe('Observable.prototype.timestamp', () => {
     const e1subs =   '^  !';
     const expected = '---#';
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -130,11 +135,11 @@ describe('Observable.prototype.timestamp', () => {
     const expected = '-y--z--#';
 
     const expectedValue = {
-      y: new Rx.Timestamp('a', 10),
-      z: new Rx.Timestamp('b', 40)
+      y: new Timestamp('a', 10),
+      z: new Timestamp('b', 40)
     };
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected, expectedValue);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -143,7 +148,7 @@ describe('Observable.prototype.timestamp', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.timestamp(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -1,19 +1,18 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { toArray, mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
 
-const Observable = Rx.Observable;
-
 /** @test {toArray} */
-describe('Observable.prototype.toArray', () => {
+describe('toArray operator', () => {
   asDiagram('toArray')('should reduce the values of an observable into an array', () => {
     const e1 =   hot('---a--b--|');
     const e1subs =   '^        !';
     const expected = '---------(w|)';
 
-    expectObservable(e1.toArray()).toBe(expected, { w: ['a', 'b'] });
+    expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['a', 'b'] });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -22,7 +21,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.toArray()).toBe(expected);
+    expectObservable(e1.pipe(toArray())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -31,7 +30,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =   '(^!)';
     const expected = '(w|)';
 
-    expectObservable(e1.toArray()).toBe(expected, { w: [] });
+    expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -40,7 +39,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =      '^     ';
     const expected =    '------';
 
-    expectObservable(e1.toArray()).toBe(expected);
+    expectObservable(e1.pipe(toArray())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -49,7 +48,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =    '^   !';
     const expected =  '----(w|)';
 
-    expectObservable(e1.toArray()).toBe(expected, { w: [] });
+    expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -58,7 +57,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =    '^     !';
     const expected =  '------(w|)';
 
-    expectObservable(e1.toArray()).toBe(expected, { w: ['y'] });
+    expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['y'] });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -67,7 +66,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =    '^     !';
     const expected =  '------(w|)';
 
-    const result = e1.toArray();
+    const result = e1.pipe(toArray());
     expectObservable(result).toBe(expected, { w: ['y'] });
     expectObservable(result).toBe(expected, { w: ['y'] });
     expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
@@ -79,7 +78,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =   '^       !                 ';
     const expected = '---------                 ';
 
-    expectObservable(e1.toArray(), unsub).toBe(expected);
+    expectObservable(e1.pipe(toArray()), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -89,10 +88,11 @@ describe('Observable.prototype.toArray', () => {
     const expected = '---------                 ';
     const unsub =    '        !                 ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .toArray()
-      .mergeMap((x: Array<string>) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      toArray(),
+      mergeMap((x: Array<string>) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -103,7 +103,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =    '^        !';
     const expected =  '---------#';
 
-    expectObservable(e1.toArray()).toBe(expected, null, 'too bad');
+    expectObservable(e1.pipe(toArray())).toBe(expected, null, 'too bad');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -112,7 +112,7 @@ describe('Observable.prototype.toArray', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.toArray()).toBe(expected);
+    expectObservable(e1.pipe(toArray())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -121,6 +121,6 @@ describe('Observable.prototype.toArray', () => {
       val: 3
     };
 
-    Observable.of(typeValue).toArray().subscribe(x => { x[0].val.toString(); });
+    of(typeValue).pipe(toArray()).subscribe(x => { x[0].val.toString(); });
   });
 });

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -1,26 +1,24 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
-
-const Observable = Rx.Observable;
+import { of, EMPTY, throwError, config } from 'rxjs';
 
 /** @test {toPromise} */
-describe('Observable.prototype.toPromise', () => {
+describe('Observable.toPromise', () => {
   it('should convert an Observable to a promise of its last value', (done: MochaDone) => {
-    Observable.of(1, 2, 3).toPromise(Promise).then((x: number) => {
+    of(1, 2, 3).toPromise(Promise).then((x: number) => {
       expect(x).to.equal(3);
       done();
     });
   });
 
   it('should convert an empty Observable to a promise of undefined', (done: MochaDone) => {
-    Observable.empty().toPromise(Promise).then((x) => {
+    EMPTY.toPromise(Promise).then((x) => {
       expect(x).to.be.undefined;
       done();
     });
   });
 
   it('should handle errors properly', (done: MochaDone) => {
-    Observable.throw('bad').toPromise(Promise).then(() => {
+    throwError('bad').toPromise(Promise).then(() => {
       done(new Error('should not be called'));
     }, (err: any) => {
       expect(err).to.equal('bad');
@@ -28,14 +26,14 @@ describe('Observable.prototype.toPromise', () => {
     });
   });
 
-  it('should allow for global config via Rx.config.Promise', (done: MochaDone) => {
+  it('should allow for global config via config.Promise', (done: MochaDone) => {
     let wasCalled = false;
-    Rx.config.Promise = function MyPromise(callback: Function) {
+    config.Promise = function MyPromise(callback: Function) {
       wasCalled = true;
       return new Promise(callback as any);
     } as any;
 
-    Observable.of(42).toPromise().then((x: number) => {
+    of(42).toPromise().then((x: number) => {
       expect(wasCalled).to.be.true;
       expect(x).to.equal(42);
       done();

--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -1,14 +1,15 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { window, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { EMPTY, of, Observable } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {window} */
-describe('Observable.prototype.window', () => {
+describe('window operator', () => {
   asDiagram('window')('should emit windows that close and reopen', () => {
     const source =   hot('---a---b---c---d---e---f---g---h---i---|    ');
     const sourceSubs =   '^                                      !    ';
@@ -20,7 +21,7 @@ describe('Observable.prototype.window', () => {
     const z = cold(                                '-g---h---i---|    ');
     const expectedValues = { x: x, y: y, z: z };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -36,7 +37,7 @@ describe('Observable.prototype.window', () => {
     const w =         cold('|');
     const expectedValues = { w: w };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -52,7 +53,7 @@ describe('Observable.prototype.window', () => {
     const w =        cold('|');
     const expectedValues = { w: w };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -66,7 +67,7 @@ describe('Observable.prototype.window', () => {
     const w =        cold('|');
     const expectedValues = { w: w };
 
-    const result = source.window(Observable.empty());
+    const result = source.pipe(window(EMPTY));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -83,7 +84,7 @@ describe('Observable.prototype.window', () => {
     const w =        cold('(a|)');
     const expectedValues = { w: w };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -99,7 +100,7 @@ describe('Observable.prototype.window', () => {
     const w =        cold('------');
     const expectedValues = { w: w };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -117,7 +118,7 @@ describe('Observable.prototype.window', () => {
     const c =        cold(     '---|');
     const expectedValues = { a: a, b: b, c: c };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -133,7 +134,7 @@ describe('Observable.prototype.window', () => {
     const w =        cold('#');
     const expectedValues = { w: w };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -152,7 +153,7 @@ describe('Observable.prototype.window', () => {
     const d = cold(                     '-9-|         ');
     const expectedValues = { a: a, b: b, c: c, d: d };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -171,7 +172,7 @@ describe('Observable.prototype.window', () => {
     const d = cold(                     '-9-#         ');
     const expectedValues = { a: a, b: b, c: c, d: d };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -189,7 +190,7 @@ describe('Observable.prototype.window', () => {
     const unsub =           '        !                ';
     const expectedValues = { a: a, b: b };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -207,10 +208,11 @@ describe('Observable.prototype.window', () => {
     const unsub =           '        !                ';
     const expectedValues = { a: a, b: b };
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .window(closings)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      window(closings),
+      mergeMap((x: Observable<string>) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -226,7 +228,7 @@ describe('Observable.prototype.window', () => {
     const a = cold(         '-3-4#           ');
     const expectedValues = { a: a };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -244,7 +246,7 @@ describe('Observable.prototype.window', () => {
     const c = cold(                 '-7-8|   ');
     const expectedValues = { a: a, b: b, c: c };
 
-    const result = source.window(closings);
+    const result = source.pipe(window(closings));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/windowCount-spec.ts
+++ b/spec/operators/windowCount-spec.ts
@@ -1,14 +1,15 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { windowCount, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of, Observable } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {windowCount} */
-describe('Observable.prototype.windowCount', () => {
+describe('windowCount operator', () => {
   asDiagram('windowCount(3)')('should emit windows with count 3, no skip specified', () => {
     const source =   hot('---a---b---c---d---e---f---g---h---i---|');
     const sourceSubs =   '^                                      !';
@@ -19,7 +20,7 @@ describe('Observable.prototype.windowCount', () => {
     const w = cold(                                         '----|');
     const expectedValues = { x: x, y: y, z: z, w: w };
 
-    const result = source.windowCount(3);
+    const result = source.pipe(windowCount(3));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -36,7 +37,7 @@ describe('Observable.prototype.windowCount', () => {
     const z = cold(               '---|');
     const values = { u: u, v: v, x: x, y: y, z: z };
 
-    const result = source.windowCount(2, 1);
+    const result = source.pipe(windowCount(2, 1));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -52,7 +53,7 @@ describe('Observable.prototype.windowCount', () => {
     const w = cold(                     '---|');
     const values = { x: x, y: y, z: z, w: w };
 
-    const result = source.windowCount(2);
+    const result = source.pipe(windowCount(2));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -65,7 +66,7 @@ describe('Observable.prototype.windowCount', () => {
     const w =      cold('|');
     const values = { w: w };
 
-    const result = source.windowCount(2, 1);
+    const result = source.pipe(windowCount(2, 1));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -78,7 +79,7 @@ describe('Observable.prototype.windowCount', () => {
     const w =      cold('-');
     const expectedValues = { w: w };
 
-    const result = source.windowCount(2, 1);
+    const result = source.pipe(windowCount(2, 1));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -91,7 +92,7 @@ describe('Observable.prototype.windowCount', () => {
     const w =        cold('#');
     const expectedValues = { w: w };
 
-    const result = source.windowCount(2, 1);
+    const result = source.pipe(windowCount(2, 1));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -110,7 +111,7 @@ describe('Observable.prototype.windowCount', () => {
     const q = cold(                     '---#');
     const values = { u: u, v: v, w: w, x: x, y: y, z: z, q: q };
 
-    const result = source.windowCount(3, 1);
+    const result = source.pipe(windowCount(3, 1));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -127,7 +128,7 @@ describe('Observable.prototype.windowCount', () => {
     const unsub =      '         !     ';
     const values = { w: w, x: x, y: y, z: z };
 
-    const result = source.windowCount(2, 1);
+    const result = source.pipe(windowCount(2, 1));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -144,10 +145,11 @@ describe('Observable.prototype.windowCount', () => {
     const unsub =      '         !     ';
     const values = { w: w, x: x, y: y, z: z };
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .windowCount(2, 1)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      windowCount(2, 1),
+      mergeMap((x: Observable<string>) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -1,13 +1,14 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+import { windowTime, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { of, Observable } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {windowTime} */
-describe('Observable.prototype.windowTime', () => {
+describe('windowTime operator', () => {
   asDiagram('windowTime(50, 100)')('should emit windows given windowTimeSpan ' +
   'and windowCreationInterval', () => {
     const source = hot('--1--2--^-a--b--c--d--e---f--g--h-|');
@@ -22,7 +23,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-g--h| ');
     const values = { x, y, z };
 
-    const result = source.windowTime(50, 100, rxTestScheduler);
+    const result = source.pipe(windowTime(50, 100, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -39,7 +40,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-g-----|');
     const values = { x, y, z };
 
-    const result = source.windowTime(timeSpan, null, 2, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, null, 2, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -59,7 +60,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-h--i| ');
     const values = { x, y, z };
 
-    const result = source.windowTime(50, 100, 3, rxTestScheduler);
+    const result = source.pipe(windowTime(50, 100, 3, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -76,7 +77,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-g--h--|');
     const values = { x, y, z };
 
-    const result = source.windowTime(timeSpan, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -97,7 +98,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-g--h|  ');
     const values = { x, y, z };
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -112,7 +113,7 @@ describe('Observable.prototype.windowTime', () => {
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -127,7 +128,7 @@ describe('Observable.prototype.windowTime', () => {
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -146,7 +147,7 @@ describe('Observable.prototype.windowTime', () => {
     const unsub =         '          !';
     const expectedValues = { a, b, c, d };
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -161,7 +162,7 @@ describe('Observable.prototype.windowTime', () => {
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -182,7 +183,7 @@ describe('Observable.prototype.windowTime', () => {
     const z = cold(                                '-g--h|  ');
     const values = { x, y, z };
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -204,7 +205,7 @@ describe('Observable.prototype.windowTime', () => {
     const unsub =              '           !                ';
     const values = { x, y };
 
-    const result = source.windowTime(timeSpan, interval, rxTestScheduler);
+    const result = source.pipe(windowTime(timeSpan, interval, rxTestScheduler));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -225,10 +226,11 @@ describe('Observable.prototype.windowTime', () => {
     const unsub =              '              !             ';
     const values = { x, y };
 
-    const result = source
-      .mergeMap((x: string) => Observable.of(x))
-      .windowTime(timeSpan, interval, rxTestScheduler)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+    const result = source.pipe(
+      mergeMap((x: string) => of(x)),
+      windowTime(timeSpan, interval, rxTestScheduler),
+      mergeMap((x: Observable<string>) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(sourcesubs);

--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -1,14 +1,15 @@
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { TestScheduler } from 'rxjs/testing';
+import { windowWhen, mergeMap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {windowWhen} */
-describe('Observable.prototype.windowWhen', () => {
+describe('windowWhen operator', () => {
   asDiagram('windowWhen')('should emit windows that close and reopen', () => {
     const e1 = hot('--a--^--b--c--d--e--f--g--h--i--|');
     const e1subs =      '^                          !';
@@ -22,7 +23,7 @@ describe('Observable.prototype.windowWhen', () => {
     const expected =    'a----------b----------c----|';
     const values = { a: a, b: b, c: c };
 
-    const source = e1.windowWhen(() => e2);
+    const source = e1.pipe(windowWhen(() => e2));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -46,7 +47,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y, z: z };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -72,7 +73,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y, z: z };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++].obs);
+    const result = e1.pipe(windowWhen(() => closings[i++].obs));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -98,7 +99,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y, z: z };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -122,7 +123,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -145,10 +146,11 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .windowWhen(() => closings[i++])
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      windowWhen(() => closings[i++]),
+      mergeMap((x: Observable<string>) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -170,12 +172,12 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1.windowWhen(() => {
+    const result = e1.pipe(windowWhen(() => {
       if (i === 1) {
         throw 'error';
       }
       return closings[i++];
-    });
+    }));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -196,7 +198,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -218,7 +220,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -240,7 +242,7 @@ describe('Observable.prototype.windowWhen', () => {
     const values = { x: x, y: y };
 
     let i = 0;
-    const result = e1.windowWhen(() => closings[i++]);
+    const result = e1.pipe(windowWhen(() => closings[i++]));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -256,7 +258,7 @@ describe('Observable.prototype.windowWhen', () => {
     const expected = '(w|)';
     const values = { w: cold('|') };
 
-    const result = e1.windowWhen(() => e2);
+    const result = e1.pipe(windowWhen(() => e2));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -280,7 +282,7 @@ describe('Observable.prototype.windowWhen', () => {
     const expected = 'a----b----c----d--';
     const values = { a: win, b: win, c: win, d: d };
 
-    const result = e1.windowWhen(() => e2);
+    const result = e1.pipe(windowWhen(() => e2));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -296,7 +298,7 @@ describe('Observable.prototype.windowWhen', () => {
     const expected = '(w#)';
     const values = { w: win };
 
-    const result = e1.windowWhen(() => e2);
+    const result = e1.pipe(windowWhen(() => e2));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -312,7 +314,7 @@ describe('Observable.prototype.windowWhen', () => {
     const x = cold(     '----b---c---d---e---f---g---h------|');
     const values = { x: x };
 
-    const result = e1.windowWhen(() => e2);
+    const result = e1.pipe(windowWhen(() => e2));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -328,7 +330,7 @@ describe('Observable.prototype.windowWhen', () => {
     const x = cold(     '#                                   ');
     const values = { x: x };
 
-    const result = e1.windowWhen(() => e2);
+    const result = e1.pipe(windowWhen(() => e2));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/withLatestFrom-spec.ts
+++ b/spec/operators/withLatestFrom-spec.ts
@@ -1,20 +1,19 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { lowerCaseO } from '../helpers/test-helper';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { withLatestFrom, mergeMap, delay } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {withLatestFrom} */
-describe('Observable.prototype.withLatestFrom', () => {
+describe('withLatestFrom operator', () => {
   asDiagram('withLatestFrom')('should combine events from cold observables', () => {
     const e1 =  cold('-a--b-----c-d-e-|');
     const e2 =  cold('--1--2-3-4---|   ');
     const expected = '----B-----C-D-E-|';
 
-    const result = e1.withLatestFrom(e2, (a: string, b: string) => String(a) + String(b));
+    const result = e1.pipe(withLatestFrom(e2, (a: string, b: string) => String(a) + String(b)));
 
     expectObservable(result).toBe(expected, { B: 'b1', C: 'c4', D: 'd4', E: 'e4' });
   });
@@ -33,7 +32,7 @@ describe('Observable.prototype.withLatestFrom', () => {
       z: ['d', 'h', 'l']
     };
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -57,7 +56,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     };
     const project = function (a: string, b: string, c: string) { return a + b + c; };
 
-    const result = e1.withLatestFrom(e2, e3, project);
+    const result = e1.pipe(withLatestFrom(e2, e3, project));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -81,7 +80,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     };
     const project = function (a: string, b: string, c: string) { return a + b + c; };
 
-    const result = e1.withLatestFrom(e2, e3, project);
+    const result = e1.pipe(withLatestFrom(e2, e3, project));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -105,10 +104,11 @@ describe('Observable.prototype.withLatestFrom', () => {
     };
     const project = function (a: string, b: string, c: string) { return a + b + c; };
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .withLatestFrom(e2, e3, project)
-      .mergeMap((x: string) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      withLatestFrom(e2, e3, project),
+      mergeMap((x: string) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -125,7 +125,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const e3subs =        '(^!)';
     const expected =      '|'; // empty
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -142,7 +142,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const e3subs =        '^              !';
     const expected =      '--------------------'; // never
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -159,7 +159,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const e3subs =        '(^!)';
     const expected =      '#'; // throw
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -179,7 +179,7 @@ describe('Observable.prototype.withLatestFrom', () => {
       x: ['b', 'f', 'j']
     };
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected, values, new Error('boo-hoo'));
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -200,7 +200,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     };
     const project = function (a: string, b: string, c: string) { return a + b + c; };
 
-    const result = e1.withLatestFrom(e2, e3, project);
+    const result = e1.pipe(withLatestFrom(e2, e3, project));
 
     expectObservable(result).toBe(expected, values, new Error('boo-hoo'));
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -217,7 +217,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const e3subs =        '^             !   ';
     const expected =      '--------------|   ';
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -234,7 +234,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const e3subs =        '^             !   ';
     const expected =      '--------------|   ';
 
-    const result = e1.withLatestFrom(e2, e3);
+    const result = e1.pipe(withLatestFrom(e2, e3));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -243,21 +243,21 @@ describe('Observable.prototype.withLatestFrom', () => {
   });
 
   it('should handle promises', (done: MochaDone) => {
-    Observable.of(1).delay(1).withLatestFrom(Promise.resolve(2), Promise.resolve(3))
+    of(1).pipe(delay(1), withLatestFrom(Promise.resolve(2), Promise.resolve(3)))
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 2, 3]);
       }, null, done);
   });
 
   it('should handle arrays', () => {
-    Observable.of(1).delay(1).withLatestFrom([2, 3, 4], [4, 5, 6])
+    of(1).pipe(delay(1), withLatestFrom([2, 3, 4], [4, 5, 6]))
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 4, 6]);
       });
   });
 
   it('should handle lowercase-o observables', () => {
-    Observable.of(1).delay(1).withLatestFrom(lowerCaseO(2, 3, 4), lowerCaseO(4, 5, 6))
+    of(1).pipe(delay(1), withLatestFrom(lowerCaseO(2, 3, 4), lowerCaseO(4, 5, 6)))
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 4, 6]);
       });

--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -1,14 +1,12 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { zip, mergeMap } from 'rxjs/operators';
+import { queueScheduler, from, of, Observable } from 'rxjs';
 
 declare const type: Function;
 
-const Observable = Rx.Observable;
-const queueScheduler = Rx.Scheduler.queue;
-
 /** @test {zip} */
-describe('Observable.prototype.zip', () => {
+describe('zip operator', () => {
   it('should combine a source with a second', () => {
     const a =    hot('---1---2---3---');
     const asubs =    '^';
@@ -16,7 +14,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(a.zip(b))
+    expectObservable(a.pipe(zip(b)))
       .toBe(expected, { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -26,10 +24,10 @@ describe('Observable.prototype.zip', () => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
 
-    Observable.from(['a', 'b', 'c']).zip(
-      Observable.from([1, 2, 3]),
+    from(['a', 'b', 'c']).pipe(zip(
+      from([1, 2, 3]),
       (a, b): string => a + b
-    )
+    ))
     .subscribe(function (x) {
       expect(x).to.equal(expected[i++]);
     }, null, done);
@@ -49,7 +47,7 @@ describe('Observable.prototype.zip', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(e1.zip(e2, e3)).toBe(expected, values);
+    expectObservable(e1.pipe(zip(e2, e3))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -70,7 +68,7 @@ describe('Observable.prototype.zip', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(e1.zip(e2, e3)).toBe(expected, values);
+    expectObservable(e1.pipe(zip(e2, e3))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -97,7 +95,7 @@ describe('Observable.prototype.zip', () => {
         z: ['d', 3]
       };
 
-      expectObservable(e1.zip(myIterator)).toBe(expected, values);
+      expectObservable(e1.pipe(zip(myIterator))).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
 
@@ -112,7 +110,7 @@ describe('Observable.prototype.zip', () => {
       };
       myIterator[Symbol.iterator] = function () { return this; };
 
-      Observable.of(1, 2, 3).zip(myIterator)
+      of(1, 2, 3).pipe(zip(myIterator))
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when
@@ -126,7 +124,7 @@ describe('Observable.prototype.zip', () => {
       const b: string[] = [];
       const expected = '-';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -136,7 +134,7 @@ describe('Observable.prototype.zip', () => {
       const b: string[] = [];
       const expected = '|';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -146,7 +144,7 @@ describe('Observable.prototype.zip', () => {
       const b = [1];
       const expected = '|';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -156,7 +154,7 @@ describe('Observable.prototype.zip', () => {
       const b: string[] = [];
       const expected = '--------|';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -166,7 +164,7 @@ describe('Observable.prototype.zip', () => {
       const b = [1];
       const expected = '-';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -176,7 +174,7 @@ describe('Observable.prototype.zip', () => {
       const b = [2];
       const expected = '-----(x|)';
 
-      expectObservable(a.zip(b)).toBe(expected, { x: ['1', 2] });
+      expectObservable(a.pipe(zip(b))).toBe(expected, { x: ['1', 2] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -186,7 +184,7 @@ describe('Observable.prototype.zip', () => {
       const b: string[] = [];
       const expected = '-----#';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -196,7 +194,7 @@ describe('Observable.prototype.zip', () => {
       const b = [1];
       const expected = '-----#';
 
-      expectObservable(a.zip(b)).toBe(expected);
+      expectObservable(a.pipe(zip(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -206,7 +204,7 @@ describe('Observable.prototype.zip', () => {
       const b = [4, 5, 6];
       const expected = '---x--y--(z|)';
 
-      expectObservable(a.zip(b)).toBe(expected,
+      expectObservable(a.pipe(zip(b))).toBe(expected,
         { x: ['1', 4], y: ['2', 5], z: ['3', 6] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -223,7 +221,7 @@ describe('Observable.prototype.zip', () => {
         } else {
           return x + y;
         }};
-      expectObservable(a.zip(b, selector)).toBe(expected,
+      expectObservable(a.pipe(zip(b, selector))).toBe(expected,
         { x: '14' }, new Error('too bad'));
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -236,7 +234,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(a.zip(b, function (e1, e2) { return e1 + e2; }))
+    expectObservable(a.pipe(zip(b, function (e1, e2) { return e1 + e2; })))
       .toBe(expected, { x: '14', y: '25', z: '36' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -250,7 +248,7 @@ describe('Observable.prototype.zip', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    expectObservable(a.zip(b, c)).toBe(expected,
+    expectObservable(a.pipe(zip(b, c))).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -264,8 +262,8 @@ describe('Observable.prototype.zip', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = a.zip(b, c,
-      function (r0, r1, r2) { return [r0, r1, r2]; });
+    const observable = a.pipe(zip(b, c,
+      function (r0, r1, r2) { return [r0, r1, r2]; }));
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -280,8 +278,8 @@ describe('Observable.prototype.zip', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = a.zip(b, c,
-      function (r0, r1, r2) { return [r0, r1, r2]; });
+    const observable = a.pipe(zip(b, c,
+      function (r0, r1, r2) { return [r0, r1, r2]; }));
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -295,7 +293,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(a.zip(b, function (r1, r2) { return r1 + r2; }))
+    expectObservable(a.pipe(zip(b, function (r1, r2) { return r1 + r2; })))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -308,7 +306,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(a.zip(b, function (r1, r2) { return r1 + r2; }))
+    expectObservable(a.pipe(zip(b, function (r1, r2) { return r1 + r2; })))
       .toBe(expected, { a: '21', b: '43', c: '65', d: '87', e: '09' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -321,7 +319,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =      '^                ! ';
     const expected =   '---a--b--c--d--e-| ';
 
-    expectObservable(a.zip(b, function (r1, r2) { return r1 + r2; }))
+    expectObservable(a.pipe(zip(b, function (r1, r2) { return r1 + r2; })))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -340,7 +338,7 @@ describe('Observable.prototype.zip', () => {
       } else {
         return x + y;
       }};
-    const observable = a.zip(b, selector);
+    const observable = a.pipe(zip(b, selector));
     expectObservable(observable).toBe(expected,
       { x: '23' }, new Error('too bad'));
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -354,7 +352,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =      '^     !';
     const expected =   '---x--|';
 
-    expectObservable(a.zip(b)).toBe(expected, { x: ['2', '3'] });
+    expectObservable(a.pipe(zip(b))).toBe(expected, { x: ['2', '3'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -366,7 +364,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -378,7 +376,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -390,7 +388,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -402,7 +400,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -414,7 +412,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -426,7 +424,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -438,7 +436,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^     !';
     const expected = '-';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -450,7 +448,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -462,7 +460,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -474,7 +472,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -486,7 +484,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^     !    ';
     const expected = '------#    ';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -498,7 +496,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -510,7 +508,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -522,7 +520,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(a.zip(b)).toBe(expected, null, 'too bad');
+    expectObservable(a.pipe(zip(b))).toBe(expected, null, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -534,7 +532,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(a.zip(b)).toBe(expected, { x: [1, 2] }, 'too bad');
+    expectObservable(a.pipe(zip(b))).toBe(expected, { x: [1, 2] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -546,7 +544,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(a.zip(b)).toBe(expected, { x: [2, 1] }, 'too bad');
+    expectObservable(a.pipe(zip(b))).toBe(expected, { x: [2, 1] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -558,18 +556,18 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '(^!)';
     const expected = '#';
 
-    expectObservable(a.zip(b)).toBe(expected);
+    expectObservable(a.pipe(zip(b))).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
 
   it('should combine an immediately-scheduled source with an immediately-scheduled second', (done) => {
-    const a = Observable.of<number>(1, 2, 3, queueScheduler);
-    const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
+    const a = of<number>(1, 2, 3, queueScheduler);
+    const b = of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    a.zip(b).subscribe(function (vals) {
+    a.pipe(zip(b)).subscribe(function (vals) {
       expect(vals).to.deep.equal(r[i++]);
     }, null, done);
   });
@@ -582,10 +580,11 @@ describe('Observable.prototype.zip', () => {
     const bsubs =    '^        !';
     const expected = '---x---y--';
 
-    const r = a
-      .mergeMap((x) => Observable.of(x))
-      .zip(b)
-      .mergeMap((x) => Observable.of(x));
+    const r = a.pipe(
+      mergeMap((x) => of(x)),
+      zip(b),
+      mergeMap((x) => of(x))
+    );
 
     expectObservable(r, unsub).toBe(expected, { x: ['1', '4'], y: ['2', '5']});
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -594,25 +593,25 @@ describe('Observable.prototype.zip', () => {
 
   type('should support rest parameter observables', () => {
     /* tslint:disable:no-unused-variable */
-    let o: Rx.Observable<number>;
-    let z: Rx.Observable<number>[];
-    let a: Rx.Observable<number[]> = o.zip(...z);
+    let o: Observable<number>;
+    let z: Observable<number>[];
+    let a: Observable<number[]> = o.pipe(zip(...z));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support projected rest parameter observables', () => {
     /* tslint:disable:no-unused-variable */
-    let o: Rx.Observable<number>;
-    let z: Rx.Observable<number>[];
-    let a: Rx.Observable<string[]> = o.zip(...z, (...r) => r.map(v => v.toString()));
+    let o: Observable<number>;
+    let z: Observable<number>[];
+    let a: Observable<string[]> = o.pipe(zip(...z, (...r) => r.map(v => v.toString())));
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support projected arrays of observables', () => {
     /* tslint:disable:no-unused-variable */
-    let o: Rx.Observable<number>;
-    let z: Rx.Observable<number>[];
-    let a: Rx.Observable<string[]> = o.zip(z, (...r: any[]) => r.map(v => v.toString()));
+    let o: Observable<number>;
+    let z: Observable<number>[];
+    let a: Observable<string[]> = o.pipe(zip(z, (...r: any[]) => r.map(v => v.toString())));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -1,21 +1,20 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { zipAll, mergeMap } from 'rxjs/operators';
+import { queueScheduler, of, zip, Observable } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 declare const type: Function;
-const Observable = Rx.Observable;
-const queueScheduler = Rx.Scheduler.queue;
 
 /** @test {zipAll} */
-describe('Observable.prototype.zipAll', () => {
+describe('zipAll operator', () => {
   asDiagram('zipAll')('should combine paired events from two observables', () => {
     const x =    cold(               '-a-----b-|');
     const y =    cold(               '--1-2-----');
     const outer = hot('-x----y--------|         ', { x: x, y: y });
     const expected =  '-----------------A----B-|';
 
-    const result = outer.zipAll((a, b) => String(a) + String(b));
+    const result = outer.pipe(zipAll((a, b) => String(a) + String(b)));
 
     expectObservable(result).toBe(expected, { A: 'a1', B: 'b2' });
   });
@@ -28,7 +27,7 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y---z';
     const values = { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] };
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, values);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -36,11 +35,11 @@ describe('Observable.prototype.zipAll', () => {
   it('should take all observables from the source and zip them', (done) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
-    Observable.of(
-      Observable.of('a', 'b', 'c'),
-      Observable.of(1, 2, 3)
+    of(
+      of('a', 'b', 'c'),
+      of(1, 2, 3)
     )
-    .zipAll((a, b) => a + b)
+    .pipe(zipAll((a, b) => a + b))
     .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);
@@ -60,7 +59,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(of(e1, e2, e3).pipe(zipAll())).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -81,7 +80,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(of(e1, e2, e3).pipe(zipAll())).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -110,7 +109,7 @@ describe('Observable.prototype.zipAll', () => {
         z: ['d', 3]
       };
 
-      expectObservable(Observable.of(e1, myIterator).zipAll()).toBe(expected, values);
+      expectObservable(of(e1, myIterator).pipe(zipAll())).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
 
@@ -127,7 +126,7 @@ describe('Observable.prototype.zipAll', () => {
         }
       };
 
-      Observable.of(Observable.of(1, 2, 3), myIterator).zipAll()
+      of(of(1, 2, 3), myIterator).pipe(zipAll())
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when
@@ -141,7 +140,7 @@ describe('Observable.prototype.zipAll', () => {
       const b: string[] = [];
       const expected = '-';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -151,7 +150,7 @@ describe('Observable.prototype.zipAll', () => {
       const b: string[] = [];
       const expected = '|';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -161,7 +160,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '|';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -171,7 +170,7 @@ describe('Observable.prototype.zipAll', () => {
       const b: string[] = [];
       const expected = '--------|';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -181,7 +180,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -191,7 +190,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [2];
       const expected = '-----(x|)';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected, { x: ['1', 2] });
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected, { x: ['1', 2] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -201,7 +200,7 @@ describe('Observable.prototype.zipAll', () => {
       const b: string[] = [];
       const expected = '-----#';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -211,7 +210,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-----#';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -221,7 +220,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [4, 5, 6];
       const expected = '---x--y--(z|)';
 
-      expectObservable(Observable.of(a, b).zipAll()).toBe(expected,
+      expectObservable(of(a, b).pipe(zipAll())).toBe(expected,
         { x: ['1', 4], y: ['2', 5], z: ['3', 6] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -238,7 +237,7 @@ describe('Observable.prototype.zipAll', () => {
         } else {
           return x + y;
         }};
-      expectObservable(Observable.of(a, b).zipAll(selector)).toBe(expected,
+      expectObservable(of(a, b).pipe(zipAll(selector))).toBe(expected,
         { x: '14' }, new Error('too bad'));
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -251,7 +250,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of(a, b).zipAll((e1, e2) => e1 + e2))
+    expectObservable(of(a, b).pipe(zipAll((e1, e2) => e1 + e2)))
       .toBe(expected, { x: '14', y: '25', z: '36' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -265,7 +264,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    expectObservable(Observable.of(a, b, c).zipAll()).toBe(expected,
+    expectObservable(of(a, b, c).pipe(zipAll())).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -279,7 +278,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = of(a, b, c).pipe(zipAll((r0, r1, r2) => [r0, r1, r2]));
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -294,7 +293,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = of(a, b, c).pipe(zipAll((r0, r1, r2) => [r0, r1, r2]));
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -308,7 +307,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of(a, b).zipAll((r1, r2) => r1 + r2))
+    expectObservable(of(a, b).pipe(zipAll((r1, r2) => r1 + r2)))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -321,7 +320,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of(a, b).zipAll((r1, r2) => r1 + r2))
+    expectObservable(of(a, b).pipe(zipAll((r1, r2) => r1 + r2)))
       .toBe(expected, { a: '21', b: '43', c: '65', d: '87', e: '09' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -334,7 +333,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                ! ';
     const expected =   '---a--b--c--d--e-| ';
 
-    expectObservable(Observable.of(a, b).zipAll((r1, r2) => r1 + r2))
+    expectObservable(of(a, b).pipe(zipAll((r1, r2) => r1 + r2)))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -353,7 +352,7 @@ describe('Observable.prototype.zipAll', () => {
       } else {
         return x + y;
       }};
-    const observable = Observable.of(a, b).zipAll(selector);
+    const observable = of(a, b).pipe(zipAll(selector));
     expectObservable(observable).toBe(expected,
       { x: '23' }, new Error('too bad'));
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -367,7 +366,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^     !';
     const expected =   '---x--|';
 
-    expectObservable(Observable.zip(a, b)).toBe(expected, { x: ['2', '3'] });
+    expectObservable(zip(a, b)).toBe(expected, { x: ['2', '3'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -375,11 +374,11 @@ describe('Observable.prototype.zipAll', () => {
   it('should zip until one child terminates', (done) => {
     const expected = ['a1', 'b2'];
     let i = 0;
-    Observable.of(
-      Observable.of('a', 'b', 'c'),
-      Observable.of(1, 2)
+    of(
+      of('a', 'b', 'c'),
+      of(1, 2)
     )
-    .zipAll((a, b) => a + b)
+    .pipe(zipAll((a, b) => a + b))
     .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);
@@ -399,7 +398,7 @@ describe('Observable.prototype.zipAll', () => {
       w: ['c', 'f']
     };
 
-    expectObservable(e1.zipAll()).toBe(expected, values);
+    expectObservable(e1.pipe(zipAll())).toBe(expected, values);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -420,7 +419,7 @@ describe('Observable.prototype.zipAll', () => {
       v: ['b', 'd', 'h']
     };
 
-    expectObservable(e1.zipAll()).toBe(expected, values);
+    expectObservable(e1.pipe(zipAll())).toBe(expected, values);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -443,7 +442,7 @@ describe('Observable.prototype.zipAll', () => {
       v: ['b', 'd', 'h']
     };
 
-    expectObservable(e1.zipAll()).toBe(expected, expectedValues);
+    expectObservable(e1.pipe(zipAll())).toBe(expected, expectedValues);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -457,7 +456,7 @@ describe('Observable.prototype.zipAll', () => {
     const e1subs =   '^               !';
     const expected = '----------------#';
 
-    expectObservable(e1.zipAll()).toBe(expected);
+    expectObservable(e1.pipe(zipAll())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -468,7 +467,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -480,7 +479,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -492,7 +491,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -504,7 +503,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -516,7 +515,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -528,7 +527,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -540,7 +539,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '-';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -552,7 +551,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -564,7 +563,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of(a, b).zipAll())
+    expectObservable(of(a, b).pipe(zipAll()))
       .toBe(expected, { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -577,7 +576,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -589,7 +588,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -601,7 +600,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !    ';
     const expected = '------#    ';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -613,7 +612,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -625,7 +624,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -637,7 +636,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, null, 'too bad');
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected, null, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -649,7 +648,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, { x: [1, 2] }, 'too bad');
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected, { x: [1, 2] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -661,7 +660,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, { x: [2, 1] }, 'too bad');
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected, { x: [2, 1] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -673,18 +672,18 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '#';
 
-    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
+    expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
 
   it('should combine two immediately-scheduled observables', (done) => {
-    const a = Observable.of(1, 2, 3, queueScheduler);
-    const b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
+    const a = of(1, 2, 3, queueScheduler);
+    const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    const result = Observable.of(a, b, queueScheduler).zipAll();
+    const result = of(a, b, queueScheduler).pipe(zipAll());
 
     result.subscribe((vals) => {
       expect(vals).to.deep.equal(r[i++]);
@@ -692,12 +691,12 @@ describe('Observable.prototype.zipAll', () => {
   });
 
   it('should combine a source with an immediately-scheduled source', (done) => {
-    const a = Observable.of(1, 2, 3, queueScheduler);
-    const b = Observable.of(4, 5, 6, 7, 8);
+    const a = of(1, 2, 3, queueScheduler);
+    const b = of(4, 5, 6, 7, 8);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    const result = Observable.of(a, b, queueScheduler).zipAll();
+    const result = of(a, b, queueScheduler).pipe(zipAll());
 
     result.subscribe((vals) => {
       expect(vals).to.deep.equal(r[i++]);
@@ -713,10 +712,11 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y--';
     const values = { x: ['1', '4'], y: ['2', '5']};
 
-    const r = Observable.of(a, b)
-      .mergeMap((x) => Observable.of(x))
-      .zipAll()
-      .mergeMap((x) => Observable.of(x));
+    const r = of(a, b).pipe(
+      mergeMap((x) => of(x)),
+      zipAll(),
+      mergeMap((x) => of(x))
+    );
 
     expectObservable(r, unsub).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -727,106 +727,98 @@ describe('Observable.prototype.zipAll', () => {
     const source = hot('|');
     const expected =   '|';
 
-    expectObservable(source.zipAll()).toBe(expected);
+    expectObservable(source.pipe(zipAll())).toBe(expected);
   });
 
   type(() => {
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<number[]> = Rx.Observable
-      .of(source1, source2, source3)
-      .pipe(Rx.operators.zipAll());
+    let result: Observable<number[]> = of(source1, source2, source3)
+      .pipe(zipAll());
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<number> = Rx.Observable
-      .of(source1, source2, source3)
-      .pipe(Rx.operators.zipAll((...args) => args.reduce((acc, x) => acc + x, 0)));
+    let result: Observable<number> = of(source1, source2, source3)
+      .pipe(zipAll((...args) => args.reduce((acc, x) => acc + x, 0)));
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<number[]> = Rx.Observable
-      .of(source1, source2, source3)
-      .zipAll();
+    let result: Observable<number[]> = of(source1, source2, source3)
+      .pipe(zipAll());
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<number> = Rx.Observable
-      .of(source1, source2, source3)
-      .zipAll((...args) => args.reduce((acc, x) => acc + x, 0));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Rx.Observable<string[]> = Rx.Observable
-      .of(<any>source1, <any>source2, <any>source3)
-      .pipe(Rx.operators.zipAll<string>());
+    let result: Observable<number> = of(source1, source2, source3)
+      .pipe(zipAll((...args) => args.reduce((acc, x) => acc + x, 0)));
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     // coerce type to a specific type
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<string> = Rx.Observable
-      .of(<any>source1, <any>source2, <any>source3)
-      .pipe(Rx.operators.zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
+    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3)
+      .pipe(zipAll<string>());
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     // coerce type to a specific type
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<string[]> = Rx.Observable
-      .of(<any>source1, <any>source2, <any>source3)
-      .zipAll<string>();
+    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
+      .pipe(zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
     /* tslint:enable:no-unused-variable */
   });
 
   type(() => {
     // coerce type to a specific type
     /* tslint:disable:no-unused-variable */
-    const source1 = Rx.Observable.of(1, 2, 3);
+    const source1 = of(1, 2, 3);
     const source2 = [1, 2, 3];
     const source3 = new Promise<number>(d => d(1));
 
-    let result: Rx.Observable<string> = Rx.Observable
-      .of(<any>source1, <any>source2, <any>source3)
-      .zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0));
+    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3)
+      .pipe(zipAll<string>());
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
+      .pipe(zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
     /* tslint:enable:no-unused-variable */
   });
 });


### PR DESCRIPTION
* refactor(observeOn-spec): update observeOn operator tests to use pipeable operators

* refactor(onErrorResumeNext-spec): update onErrorResumeNext operator tests to use pipeable operators

* refactor(pairwise-spec): update pairwise operator tests to use pipeable operators

* refactor(pluck-spec): update pluck operator tests to use pipeable operators

* refactor(publish-spec): update publish operator tests to use pipeable operators

* refactor(publishBehavior-spec): update publishBehavior operator tests to use pipeable operators

* refactor(publishLast-spec): update publishLast operator tests to use pipeable operators

* refactor(publishReplay-spec): update publishReplay operator tests to use pipeable operators

* refactor(reduce-spec): update reduce operator tests to use pipeable operators

* refactor(repeat-spec): update repeat operator tests to use pipeable operators

* refactor(repeatWhen-spec): update repeatWhen operator tests to use pipeable operators

* refactor(retry-spec): update retry operator tests to use pipeable operators

* refactor(retryWhen-spec): update retryWhen operator tests to use pipeable operators

* refactor(sample-spec): update sample operator tests to use pipeable operators

* refactor(sampleTime-spec): update sampleTime operator tests to use pipeable operators

* refactor(scan-spec): update scan operator tests to use pipeable operators

* refactor(sequenceEqual-spec): update sequenceEqual operator tests to use pipeable operators

* refactor(share-spec): update share operator tests to use pipeable operators

* refactor(shareReplay-spec): update shareReplay operator tests to use pipeable operators

* refactor(single-spec): update single operator tests to use pipeable operators

* refactor(skip-spec): update skip operator tests to use pipeable operators

* refactor(skipLast-spec): update skipLast operator tests to use pipeable operators

* refactor(skipWhile-spec): update skipWhile operator tests to use pipeable operators

* refactor(startWith-spec): update startWith operator tests to use pipeable operators

* refactor(subscribeOn-spec): update subscribeOn operator tests to use pipeable operators

* refactor(switchMap-spec): update switchMap operator tests to use pipeable operators

* refactor(switchMapTo-spec): update switchMapTo operator tests to use pipeable operators

* refactor(take-spec): update take operator tests to use pipeable operators

* refactor(takeLast-spec): update takeLast operator tests to use pipeable operators

* refactor(takeUntil-spec): update takeUntil operator tests to use pipeable operators

* refactor(takeWhile-spec): update takeWhile operator tests to use pipeable operators

* refactor(throttle-spec): update throttle operator tests to use pipeable operators

* refactor(throttleTime-spec): update throttleTime operator tests to use pipeable operators

* refactor(timeout-spec): update timeout operator tests to use pipeable operators

* refactor(timeoutWith-spec): update timeoutWith operator tests to use pipeable operators

* refactor(timestamp-spec): update timestamp operator tests to use pipeable operators

* refactor(toArray-spec): update toArray operator tests to use pipeable operators

* refactor(toPromise-spec): update toPromise Observable method tests to use pipeable operators and upd

* refactor(window-spec): update window operator tests to use pipeable operators

* refactor(windowCount-spec): update windowCount operator tests to use pipeable operators

* refactor(windowTime-spec): update windowTime operator tests to use pipeable operators

* refactor(windowWhen-spec): update windowWhen operator tests to use pipeable operators

* refactor(withLatestFrom-spec): update withLatestFrom operator tests to use pipeable operators

* refactor(zip-spec): update zip operator tests to use pipeable operators

* refactor(zipAll-spec): update zipAll operator tests to use pipeable operators

* refactor(timeInterval-spec): update timeInterval operator tests to use pipeable operators

* refactor(race-spec): update race operator tests to use pipeable operators

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
