### PR TITLE
Running second selective copy of kube-scheduler

### DIFF
--- a/spec-dtslint/operators/dematerialize-spec.ts
+++ b/spec-dtslint/operators/dematerialize-spec.ts
@@ -1,0 +1,14 @@
+import { of, Notification } from 'rxjs';
+import { dematerialize } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(Notification.createNext('foo')).pipe(dematerialize()); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of(Notification.createNext('foo')).pipe(dematerialize(() => {})); // $ExpectError
+});
+
+it('should enforce Notification source', () => {
+  const o = of('foo').pipe(dematerialize()); // $ExpectError
+});

--- a/spec-dtslint/operators/elementAt-spec.ts
+++ b/spec-dtslint/operators/elementAt-spec.ts
@@ -1,0 +1,22 @@
+import { of } from 'rxjs';
+import { elementAt } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('foo').pipe(elementAt(47)); // $ExpectType Observable<string>
+});
+
+it('should support a default value', () => {
+  const o = of('foo').pipe(elementAt(47, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of('foo').pipe(elementAt()); // $ExpectError
+});
+
+it('should enforce of index', () => {
+  const o = of('foo').pipe(elementAt('foo')); // $ExpectError
+});
+
+it('should enforce of default', () => {
+  const o = of('foo').pipe(elementAt(5, 5)); // $ExpectError
+});

--- a/spec-dtslint/operators/finalize-spec.ts
+++ b/spec-dtslint/operators/finalize-spec.ts
@@ -1,0 +1,11 @@
+import { of } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(finalize(() => {})); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(finalize()); // $ExpectError
+  const p = of(1, 2, 3).pipe(finalize((value => {}))); // $ExpectError
+});

--- a/spec-dtslint/operators/materialize-spec.ts
+++ b/spec-dtslint/operators/materialize-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { materialize } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('foo').pipe(materialize()); // $ExpectType Observable<Notification<string>>
+});
+
+it('should enforce types', () => {
+  const o = of('foo').pipe(materialize(() => {})); // $ExpectError
+});

--- a/spec-dtslint/operators/single-spec.ts
+++ b/spec-dtslint/operators/single-spec.ts
@@ -1,0 +1,34 @@
+import { of, Observable } from 'rxjs';
+import { single } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('foo').pipe(single()); // $ExpectType Observable<string>
+});
+
+it('should support a value', () => {
+  const o = of('foo').pipe(single(value => value === 'foo')); // $ExpectType Observable<string>
+});
+
+it('should support an index', () => {
+  const o = of('foo').pipe(single((value, index) => index === 2)); // $Observable<string>
+});
+
+it('should support a source', () => {
+  const o = of('foo').pipe(single((value, index, source) => value === 'foo')); // $Observable<string>
+});
+
+it('should enforce value type', () => {
+  const o = of('foo').pipe(single(((value: number) => value === 2))); // $ExpectError
+});
+
+it('should enforce return type', () => {
+  const o = of('foo').pipe(single(value => value)); // $ExpectError
+});
+
+it('should enforce index type', () => {
+  const o = of('foo').pipe(single(((value, index: string) => index === '2'))); // $ExpectError
+});
+
+it('should enforce source type', () => {
+  const o = of('foo').pipe(single(((value, index, source: Observable<number>) => value === 'foo'))); // $ExpectError
+});

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -36,9 +36,9 @@ import { Subscription } from '../Subscription';
  * );
  *
  * // Logs:
- * // ["foo": 42],
- * // ["bar": 56],
- * // ["baz": 78],
+ * // ["foo", 42],
+ * // ["bar", 56],
+ * // ["baz", 78],
  * // "the end!"
  * ```
  *


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
