### PR TITLE
corrects handling of newline after async with paren-less arrow

### DIFF
--- a/docs_app/README.md
+++ b/docs_app/README.md
@@ -20,7 +20,7 @@ Here are the most important tasks you might need to use:
 * `npm run serve-and-sync` - run both the `docs-watch` and `start` in the same console.
 * `npm run lint` - check that the doc-viewer code follows our style rules.
 * `npm test` - watch all the source files, for the doc-viewer, and run all the unit tests when any change.
-* `npm test --watch=false` - run all the unit tests once.
+* `npm test -- --watch=false` - run all the unit tests once.
 * `npm run e2e` - run all the e2e tests for the doc-viewer.
 
 * `npm run docs` - generate all the docs from the source files.
@@ -34,7 +34,7 @@ Here are the most important tasks you might need to use:
 
 Running `npm run start` (even when explicitly targeting production mode) does not set up the
 ServiceWorker. If you want to test the ServiceWorker locally, you can use `npm run build` and then
-serve the files in `dist/` with `npm run http-server dist -p 4200`.
+serve the files in `dist/` with `npm run http-server -- dist -p 4200`.
 
 ## Guide to authoring
 
@@ -93,7 +93,7 @@ npm run serve-and-sync
 ```
 
 * Open a browser at https://localhost:4200/ and navigate to the document on which you want to work.
-You can automatically open the browser by using `npm run start -o` in the first terminal.
+You can automatically open the browser by using `npm start -- -o` in the first terminal.
 
 * Make changes to the page's associated doc or example files. Every time a file is saved, the doc will
 be regenerated, the app will rebuild and the page will reload.

--- a/docs_app/content/guide/overview.md
+++ b/docs_app/content/guide/overview.md
@@ -88,7 +88,7 @@ fromEvent(button, 'click').pipe(
 .subscribe(count => console.log(`Clicked ${count} times`));
 ```
 
-Other flow control operators are [**filter**](../class/es6/Observable.js~Observable.html#instance-method-filter), [**delay**](../class/es6/Observable.js~Observable.html#instance-method-delay), [**debounceTime**](../class/es6/Observable.js~Observable.html#instance-method-debounceTime), [**take**](../class/es6/Observable.js~Observable.html#instance-method-take), [**takeUntil**](../class/es6/Observable.js~Observable.html#instance-method-takeUntil), [**distinct**](../class/es6/Observable.js~Observable.html#instance-method-distinct), [**distinctUntilChanged**](../class/es6/Observable.js~Observable.html#instance-method-distinctUntilChanged) etc.
+Other flow control operators are [**filter**](../api/operators/filter), [**delay**](../api/operators/delay), [**debounceTime**](../api/operators/debounceTime), [**take**](../api/operators/take), [**takeUntil**](../api/operators/takeUntil), [**distinct**](../api/operators/distinct), [**distinctUntilChanged**](../api/operators/distinctUntilChanged) etc.
 
 ### Values
 You can transform the values passed through your observables.
@@ -122,5 +122,4 @@ fromEvent(button, 'click').pipe(
 .subscribe(count => console.log(count));
 ```
 
-Other value producing operators are [**pluck**](../class/es6/Observable.js~Observable.html#instance-method-pluck), [**pairwise**](../class/es6/Observable.js~Observable.html#instance-method-pairwise),
-[**sample**](../class/es6/Observable.js~Observable.html#instance-method-sample) etc.
+Other value producing operators are [**pluck**](../api/operators/pluck), [**pairwise**](../api/operators/pairwise), [**sample**](../api/operators/sample) etc.

--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -18,7 +18,7 @@
         <h2 class="hero-headline no-toc">RxJS</h2>
         <span class="hero-subheadline">Reactive Extensions Library for JavaScript</span>
       </div>
-      <a class="button hero-cta" href="/api">Get Started</a>
+      <a class="button hero-cta" href="/guide/overview">Get Started</a>
     </div>
 
   </section>

--- a/docs_app/package.json
+++ b/docs_app/package.json
@@ -18,6 +18,7 @@
     "pree2e": "npm run update-webdriver",
     "e2e": "ng e2e --no-webdriver-update",
     "e2e-prod": "npm run e2e --environment=dev --target=production",
+    "http-server": "http-server",
     "test-pwa-score-localhost": "concurrently --kill-others --success first \"http-server dist -p 4200 --silent\" \"npm run test-pwa-score http://localhost:4200 90\"",
     "test-pwa-score": "node scripts/test-pwa-score",
     "deploy-production": "scripts/deploy-to-firebase.sh",

--- a/docs_app/src/styles/2-modules/_api-pages.scss
+++ b/docs_app/src/styles/2-modules/_api-pages.scss
@@ -18,6 +18,10 @@
     flex-direction: column;
     align-items: flex-start;
   }
+
+  > h1 {
+    margin-right: 1rem;
+  }
 }
 
 .api-body {

--- a/docs_app/src/styles/2-modules/_api-pages.scss
+++ b/docs_app/src/styles/2-modules/_api-pages.scss
@@ -30,6 +30,12 @@
     }
   }
 
+  .description img {
+    border: 1px solid #dfdfdf;
+    max-width: 100%;
+    width: 100%;
+  }
+
   .method-table {
     h3 {
       margin: 6px 0;

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:cover": "nyc npm test",
     "test:circular": "dependency-cruise --validate .dependency-cruiser.json -x \"^node_modules\" dist/esm5",
     "test:systemjs": "node integration/systemjs/systemjs-compatibility-spec.js",
-    "tests2png": "mkdirp tmp/docs/img && mocha --opts spec/support/tests2png.opts \"spec/**/*-spec.ts\"",
+    "tests2png": "mkdirp docs_app/content/img && mocha --opts spec/support/tests2png.opts \"spec/**/*-spec.ts\"",
     "compat_build_all": "npm-run-all compat_clean_dist compat_build_cjs compat_build_esm5 compat_build_esm2015 compat_build_esm5_for_rollup compat_build_umd compat_generate_packages",
     "compat_build_closure": "node ./tools/make-closure-compat.js",
     "compat_build_cjs": "npm-run-all compat_clean_dist_cjs compat_compile_dist_cjs",

--- a/spec-dtslint/operators/endWith-spec.ts
+++ b/spec-dtslint/operators/endWith-spec.ts
@@ -33,10 +33,10 @@ it('should infer type for rest parameters', () => {
   const a = of(1, 2, 3).pipe(endWith(4, 5, 6, 7, 8, 9, 10)); // $ExpectType Observable<number>
 });
 
-it('should accept empty parameter', () => {
-  const a = of(1, 2, 3).pipe(endWith()); // $ExpectType Observable<number>
+it('should infer with different types', () => {
+  const a = of(1, 2, 3).pipe(endWith('4', true)); // $ExpectType Observable<string | number | boolean>
 });
 
-it('should enforce type', () => {
-  const a = of(1, 2, 3).pipe(endWith('4')); // $ExpectError
+it('should accept empty parameter', () => {
+  const a = of(1, 2, 3).pipe(endWith()); // $ExpectType Observable<number>
 });

--- a/spec-dtslint/operators/throttle-spec.ts
+++ b/spec-dtslint/operators/throttle-spec.ts
@@ -1,0 +1,25 @@
+import { of, timer } from 'rxjs';
+import { throttle } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(throttle(() => timer(47))); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with a Promise', () => {
+  const o = of(1, 2, 3).pipe(throttle(() => new Promise<boolean>(() => {}))); // $ExpectType Observable<number>
+});
+
+it('should support a config', () => {
+  const o = of(1, 2, 3).pipe(throttle(() => timer(47), { leading: true, trailing: true })); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(throttle()); // $ExpectError
+  const p = of(1, 2, 3).pipe(throttle(() => {})); // $ExpectError
+});
+
+it('should enforce config types', () => {
+  const o = of(1, 2, 3).pipe(throttle(() => timer(47), { x: 1 })); // $ExpectError
+  const p = of(1, 2, 3).pipe(throttle(() => timer(47), { leading: 1, trailing: 1 })); // $ExpectError
+  const q = of(1, 2, 3).pipe(throttle(() => timer(47), null)); // $ExpectError
+});

--- a/spec-dtslint/operators/throttleTime-spec.ts
+++ b/spec-dtslint/operators/throttleTime-spec.ts
@@ -1,0 +1,29 @@
+import { of, asyncScheduler } from 'rxjs';
+import { throttleTime } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(throttleTime(47)); // $ExpectType Observable<number>
+});
+
+it('should support a scheduler', () => {
+  const o = of(1, 2, 3).pipe(throttleTime(47, asyncScheduler)); // $ExpectType Observable<number>
+});
+
+it('should support a config', () => {
+  const o = of(1, 2, 3).pipe(throttleTime(47, asyncScheduler, { leading: true, trailing: true })); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(throttleTime()); // $ExpectError
+  const p = of(1, 2, 3).pipe(throttleTime('foo')); // $ExpectError
+});
+
+it('should enforce scheduler types', () => {
+  const o = of(1, 2, 3).pipe(throttleTime(47, null)); // $ExpectError
+});
+
+it('should enforce config types', () => {
+  const o = of(1, 2, 3).pipe(throttleTime(47, asyncScheduler, { x: 1 })); // $ExpectError
+  const p = of(1, 2, 3).pipe(throttleTime(47, asyncScheduler, { leading: 1, trailing: 1 })); // $ExpectError
+  const q = of(1, 2, 3).pipe(throttleTime(47, asyncScheduler, null)); // $ExpectError
+});

--- a/spec-dtslint/util/pipe-spec.ts
+++ b/spec-dtslint/util/pipe-spec.ts
@@ -84,21 +84,21 @@ it('should enforce types for the 9th argument', () => {
   const o = pipe(a('0', '1'), a('1', '2'), a('2', '3'), a('3', '4'), a('4', '5'), a('5', '6'), a('6', '7'), a('7', '8'), a('#', '9')); // $ExpectError
 });
 
-it('should return generic OperatorFunction 1', () => {
+it('should return a non-narrowed Observable type', () => {
   const customOperator = <T>(p: T) => (a: Observable<T>) => a;
 
   const staticPipe = pipe(customOperator('infer'));
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<string>
 });
 
-it('should return generic OperatorFunction 2', () => {
+it('should return an explicit Observable type', () => {
   const customOperator = <T>() => (a: Observable<T>) => a;
 
   const staticPipe = pipe(customOperator<string>());
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<string>
 });
 
-it('should return generic OperatorFunction 3', () => {
+it('should return Observable<{}> when T cannot be inferred', () => {
   const customOperator = <T>() => (a: Observable<T>) => a;
 
   // type can't be possibly be inferred here, so it's {} instead of T.
@@ -106,7 +106,7 @@ it('should return generic OperatorFunction 3', () => {
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<{}>
 });
 
-it('should return generic function', () => {
+it('should return a non-narrowed type', () => {
   const func = pipe((value: string) => value, (value: string) => value + value);
-  const value = func("foo"); // $ExpectType string
+  const value = func('foo'); // $ExpectType string
 });

--- a/spec/helpers/tests2png/diagram-test-runner.ts
+++ b/spec/helpers/tests2png/diagram-test-runner.ts
@@ -96,7 +96,7 @@ global.asDiagram = function asDiagram(operatorLabel: string, glit: glitFn) {
         let inputStreams = getInputStreams(global.rxTestScheduler);
         global.rxTestScheduler.flush();
         inputStreams = updateInputStreamsPostFlush(inputStreams);
-        let filename = './tmp/docs/img/' + makeFilename(operatorLabel);
+        let filename = './docs_app/content/img/' + makeFilename(operatorLabel);
         painter(inputStreams, operatorLabel, outputStreams, filename);
         console.log('Painted ' + filename);
       });

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -156,7 +156,7 @@ describe('TestScheduler', () => {
   });
 
   describe('createHotObservable()', () => {
-    it('should create a cold observable', () => {
+    it('should create a hot observable', () => {
       const expected = ['A', 'B'];
       const scheduler = new TestScheduler(null);
       const source = scheduler.createHotObservable('--a---b--|', { a: 'A', b: 'B' });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -70,6 +70,12 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: PartialObserver<T>): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
+  /** @deprecated Use an observer instead of an error callback */
+  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -86,7 +86,6 @@ export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: 
  *
  * @see {@link fromEvent}
  * @see {@link fromEventPattern}
- * @see {@link fromPromise}
  *
  * @param {ObservableInput<T>} A subscription object, a Promise, an Observable-like,
  * an Array, an iterable, or an array-like object to be converted.

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -12,7 +12,7 @@ import { OperatorFunction } from '../types';
  * <span class="informal">Collects values from the past as an array, and emits
  * that array only when another Observable emits.</span>
  *
- * ![](buffer.png)
+ * ![](content/img/buffer.png)
  *
  * Buffers the incoming Observable values until the given `closingNotifier`
  * Observable emits a value, at which point it emits the buffer on the output

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -4,17 +4,17 @@ import { scalar } from '../observable/scalar';
 import { empty } from '../observable/empty';
 import { concat as concatStatic } from '../observable/concat';
 import { isScheduler } from '../util/isScheduler';
-import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
 export function endWith<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T>;
+export function endWith<T, A = T>(v1: A, scheduler?: SchedulerLike): OperatorFunction<T, T | A>;
+export function endWith<T, A = T, B = T>(v1: A, v2: B, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B>;
+export function endWith<T, A = T, B = T, C = T>(v1: A, v2: B, v3: C, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C>;
+export function endWith<T, A = T, B = T, C = T, D = T>(v1: A, v2: B, v3: C, v4: D, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D>;
+export function endWith<T, A = T, B = T, C = T, D = T, E = T>(v1: A, v2: B, v3: C, v4: D, v5: E, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E>;
+export function endWith<T, A = T, B = T, C = T, D = T, E = T, F = T>(v1: A, v2: B, v3: C, v4: D, v5: E, v6: F, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E | F>;
+export function endWith<T, Z = T>(...array: Array<Z | SchedulerLike>): OperatorFunction<T, T | Z>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -154,7 +154,7 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private subscribeToNextSource(): void {
     const next = this.nextSources.shift();
-    if (next) {
+    if (!!next) {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -2,6 +2,16 @@ import { Observable } from '../Observable';
 import { map } from './map';
 import { OperatorFunction } from '../types';
 
+/* tslint:disable:max-line-length */
+export function pluck<T, K1 extends keyof T>(k1: K1): OperatorFunction<T, T[K1]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1]>(k1: K1, k2: K2): OperatorFunction<T, T[K1][K2]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(k1: K1, k2: K2, k3: K3): OperatorFunction<T, T[K1][K2][K3]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(k1: K1, k2: K2, k3: K3, k4: K4): OperatorFunction<T, T[K1][K2][K3][K4]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
+export function pluck<T, R>(...properties: string[]): OperatorFunction<T, R>;
+/* tslint:enable:max-line-length */
+
 /**
  * Maps each source value (an object) to its specified nested property.
  *

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -6,6 +6,12 @@ import { noop } from '../util/noop';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
+/** @deprecated Use an observer instead of a complete callback */
+export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated Use an observer instead of an error callback */
+export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated Use an observer instead of a complete callback */
+export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -122,7 +122,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private throttle(value: T): void {
     const duration = this.tryDurationSelector(value);
-    if (duration) {
+    if (!!duration) {
       this.add(this._throttled = subscribeToResult(this, duration));
     }
   }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -40,6 +40,12 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 
 export interface Subscribable<T> {
   subscribe(observer?: PartialObserver<T>): Unsubscribable;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
+  /** @deprecated Use an observer instead of an error callback */
+  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -22,13 +22,13 @@ export const subscribeTo = <T>(result: ObservableInput<T>) => {
         return result.subscribe(subscriber);
       }
     };
-  } else if (result && typeof result[Symbol_observable] === 'function') {
+  } else if (!!result && typeof result[Symbol_observable] === 'function') {
     return subscribeToObservable(result as any);
   } else if (isArrayLike(result)) {
     return subscribeToArray(result);
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>);
-  } else if (result && typeof result[Symbol_iterator] === 'function') {
+  } else if (!!result && typeof result[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
