### PR TITLE
Typescript cannot display import prompt.

### DIFF
--- a/docs_app/tools/transforms/templates/api/export-base.template.html
+++ b/docs_app/tools/transforms/templates/api/export-base.template.html
@@ -5,7 +5,7 @@
   {% include "includes/security-notes.html" %}
   {% include "includes/deprecation.html" %}
   {% block overview %}{% endblock %}
-  {% include "includes/see-also.html" %}
   {% block details %}{% endblock %}
   {% include "includes/usageNotes.html" %}
+  {% include "includes/see-also.html" %}
 {% endblock %}

--- a/spec-dtslint/operators/repeat-spec.ts
+++ b/spec-dtslint/operators/repeat-spec.ts
@@ -1,0 +1,14 @@
+import { of } from 'rxjs';
+import { repeat } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(repeat()); // $ExpectType Observable<string>
+});
+
+it('should accept a count parameter', () => {
+  const o = of('a', 'b', 'c').pipe(repeat(47)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of('a', 'b', 'c').pipe(repeat('aa')); // $ExpectError
+});

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -124,7 +124,7 @@ export class Subscription implements SubscriptionLike {
 
   /**
    * Adds a tear down to be called during the unsubscribe() of this
-   * Subscription.
+   * Subscription. Can also be used to add a child subscription.
    *
    * If the tear down being added is a subscription that is already
    * unsubscribed, is the same reference `add` is being called on, or is
@@ -132,6 +132,8 @@ export class Subscription implements SubscriptionLike {
    *
    * If this subscription is already in an `closed` state, the passed
    * tear down logic will be executed immediately.
+   *
+   * When a parent subscription is unsubscribed, any child subscriptions that were added to it are also unsubscribed.
    *
    * @param {TeardownLogic} teardown The additional logic to execute on
    * teardown.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
