### PR TITLE
Fix unused variable warning.

### DIFF
--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -19,6 +19,7 @@
         <span class="hero-subheadline">Reactive Extensions Library for JavaScript</span>
       </div>
       <a class="button hero-cta" href="/guide/overview">Get Started</a>
+      <a class="button hero-cta" href="/api">API Docs</a>
     </div>
 
   </section>

--- a/docs_app/src/styles/1-layouts/_marketing-layout.scss
+++ b/docs_app/src/styles/1-layouts/_marketing-layout.scss
@@ -58,6 +58,10 @@ section#intro {
     justify-content: center;
     align-items: center;
 
+    .hero-cta + .hero-cta {
+      margin-top: 15px;
+    }
+
     @media  (max-width: 780px) {
       display: flex;
       flex-direction: column;

--- a/spec-dtslint/operators/min-spec.ts
+++ b/spec-dtslint/operators/min-spec.ts
@@ -1,17 +1,17 @@
 import { of } from 'rxjs';
-import { max } from 'rxjs/operators';
+import { min } from 'rxjs/operators';
 
 it('should infer correctly', () => {
-    const a = of(1, 2, 3).pipe(max()); // $ExpectType Observable<number>
-    const b = of('abc', 'bcd', 'def').pipe(max()); // $ExpectType Observable<string>
+    const a = of(1, 2, 3).pipe(min()); // $ExpectType Observable<number>
+    const b = of('abc', 'bcd', 'def').pipe(min()); // $ExpectType Observable<string>
 });
 
 it('should except empty comparer', () => {
-    const a = of(1, 2, 3).pipe(max()); // $ExpectType Observable<number>
+    const a = of(1, 2, 3).pipe(min()); // $ExpectType Observable<number>
 });
 
 it('should enforce comparer types', () => {
-    const a = of(1, 2, 3).pipe(max((a: number, b: number) => a - b)); // $ExpectType Observable<number>
-    const b = of(1, 2, 3).pipe(max((a: number, b: string) => 0)); // $ExpectError
-    const c = of(1, 2, 3).pipe(max((a: string, b: number) => 0)); // $ExpectError
+    const a = of(1, 2, 3).pipe(min((a: number, b: number) => a - b)); // $ExpectType Observable<number>
+    const b = of(1, 2, 3).pipe(min((a: number, b: string) => 0)); // $ExpectError
+    const c = of(1, 2, 3).pipe(min((a: string, b: number) => 0)); // $ExpectError
 });

--- a/spec-dtslint/operators/observeOn-spec.ts
+++ b/spec-dtslint/operators/observeOn-spec.ts
@@ -1,0 +1,22 @@
+import { of, asyncScheduler } from 'rxjs';
+import { observeOn } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('apple', 'banana', 'peach').pipe(observeOn(asyncScheduler)); // $ExpectType Observable<string>
+});
+
+it('should support a delay', () => {
+  const o = of('apple', 'banana', 'peach').pipe(observeOn(asyncScheduler, 47)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const p = of('apple', 'banana', 'peach').pipe(observeOn()); // $ExpectError
+});
+
+it('should enforce scheduler type', () => {
+  const p = of('apple', 'banana', 'peach').pipe(observeOn('fruit')); // $ExpectError
+});
+
+it('should enforce delay type', () => {
+  const p = of('apple', 'banana', 'peach').pipe(observeOn(asyncScheduler, '47')); // $ExpectError
+});

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -18,7 +18,7 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
 
 /**
  * A Subject is a special type of Observable that allows values to be
- * multicasted to many Observables. Subjects are like EventEmitters.
+ * multicasted to many Observers. Subjects are like EventEmitters.
  *
  * Every Subject is an Observable and an Observer. You can subscribe to a
  * Subject, and you can call next to feed values as well as error and complete.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
