### PR TITLE
Limit the use of regexes in the RFC

### DIFF
--- a/spec-dtslint/operators/partition-spec.ts
+++ b/spec-dtslint/operators/partition-spec.ts
@@ -1,0 +1,22 @@
+import * as Rx from 'rxjs/Rx';
+
+const Observable = Rx.Observable;
+
+it('should infer correctly', () => {
+  const o = Observable.of('a', 'b', 'c').partition((value, index) => true); // $ExpectType [Observable<string>, Observable<string>]
+  const p = Observable.of('a', 'b', 'c').partition(() => true); // $ExpectType [Observable<string>, Observable<string>]
+});
+
+it('should accept a thisArg parameter', () => {
+  const o = Observable.of('a', 'b', 'c').partition(() => true, 5); // $ExpectType [Observable<string>, Observable<string>]
+});
+
+it('should enforce types', () => {
+  const o = Observable.of('a', 'b', 'c').partition(); // $ExpectError
+});
+
+it('should enforce predicate types', () => {
+  const o = Observable.of('a', 'b', 'c').partition('nope'); // $ExpectError
+  const p = Observable.of('a', 'b', 'c').partition((value: number) => true); // $ExpectError
+  const q = Observable.of('a', 'b', 'c').partition((value, index: string) => true); // $ExpectError
+});

--- a/spec-dtslint/operators/shareReplay-spec.ts
+++ b/spec-dtslint/operators/shareReplay-spec.ts
@@ -1,0 +1,30 @@
+import { of, asyncScheduler } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay()); // $ExpectType Observable<string>
+});
+
+it('should support a bufferSize', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay(6)); // $ExpectType Observable<string>
+});
+
+it('should support a windowTime', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay(6, 4)); // $ExpectType Observable<string>
+});
+
+it('should support a scheduler', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay(6, 4, asyncScheduler)); // $ExpectType Observable<string>
+});
+
+it('should enforce type of bufferSize', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay('abc')); // $ExpectError
+});
+
+it('should enforce type of windowTime', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay(5, 'abc')); // $ExpectError
+});
+
+it('should enforce type of scheduler', () => {
+  const o = of('foo', 'bar', 'baz').pipe(shareReplay(5, 3, 'abc')); // $ExpectError
+});

--- a/spec-dtslint/operators/subscribeOn-spec.ts
+++ b/spec-dtslint/operators/subscribeOn-spec.ts
@@ -1,0 +1,22 @@
+import { of, asyncScheduler } from 'rxjs';
+import { subscribeOn } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(subscribeOn(asyncScheduler)); // $ExpectType Observable<string>
+});
+
+it('should support a delay ', () => {
+  const o = of('a', 'b', 'c').pipe(subscribeOn(asyncScheduler, 7)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of('a', 'b', 'c').pipe(subscribeOn()); // $ExpectError
+});
+
+it('should enforce scheduler type', () => {
+  const o = of('a', 'b', 'c').pipe(subscribeOn('nope')); // $ExpectError
+});
+
+it('should enforce delay type', () => {
+  const o = of('a', 'b', 'c').pipe(subscribeOn(asyncScheduler, 'nope')); // $ExpectError
+});

--- a/spec-dtslint/operators/throwIfEmpty-spec.ts
+++ b/spec-dtslint/operators/throwIfEmpty-spec.ts
@@ -1,0 +1,15 @@
+import { of } from 'rxjs';
+import { throwIfEmpty } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(throwIfEmpty()); // $ExpectType Observable<string>
+});
+
+it('should support an errorFactory', () => {
+  const o = of('a', 'b', 'c').pipe(throwIfEmpty(() => 47)); // $ExpectType Observable<string>
+});
+
+it('should enforce errorFactory type', () => {
+  const o = of('a', 'b', 'c').pipe(throwIfEmpty('nope')); // $ExpectError
+  const p = of('a', 'b', 'c').pipe(throwIfEmpty(x => 47)); // $ExpectError
+});

--- a/spec-dtslint/operators/timeInterval-spec.ts
+++ b/spec-dtslint/operators/timeInterval-spec.ts
@@ -1,0 +1,14 @@
+import { of, asyncScheduler } from 'rxjs';
+import { timeInterval } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(timeInterval()); // $ExpectType Observable<TimeInterval<string>>
+});
+
+it('should support a scheduler', () => {
+  const o = of('a', 'b', 'c').pipe(timeInterval(asyncScheduler)); // $ExpectType Observable<TimeInterval<string>>
+});
+
+it('should enforce scheduler type', () => {
+  const o = of('a', 'b', 'c').pipe(timeInterval('nope')); // $ExpectError
+});

--- a/spec-dtslint/operators/timestamp-spec.ts
+++ b/spec-dtslint/operators/timestamp-spec.ts
@@ -1,0 +1,14 @@
+import { of, asyncScheduler } from 'rxjs';
+import { timestamp } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp()); // $ExpectType Observable<Timestamp<string>>
+});
+
+it('should support a scheduler', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp(asyncScheduler)); // $ExpectType Observable<Timestamp<string>>
+});
+
+it('should enforce scheduler type', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp('nope')); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
