### PR TITLE
Before submitting a PR read  contributing

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -1,0 +1,238 @@
+# Operators
+
+RxJS is mostly useful for its *operators*, even though the Observable is the foundation. Operators are the essential pieces that allow complex asynchronous code to be easily composed in a declarative manner.
+
+## What are operators?
+
+Operators are **functions**. There are two kinds of operators:
+
+**Pipeable Operators** are the kind that can be piped to Observables using the syntax `observableInstance.pipe(operator())`. These include `map(...)`, `filter(...)`, and `mergeMap(...)`. When called, they do not *change* the existing Observable instance. Instead, they return a *new* Observable, whose subscription logic is based on the first Observable.
+
+<span class="informal">A Pipeable Operator is a function that creates a new Observable based on the current Observable. This is a pure operation: the previous Observable stays unmodified.</span>
+
+An Pipeable Operator is essentially a pure function which takes one Observable as input and generates another Observable as output. Subscribing to the output Observable will also subscribe to the input Observable.
+
+**Creation Operators** are the other kind of operator that can be called as standalone functions to create a new Observable. For example: `of(1, 2, 3)`. These will be discussed in more detail in the next section.
+
+In the following example, we create a custom pipeable operator function that multiplies each value received from the input Observable by 10. We test this by creating a new Observable using the creation operator function `from` which can create an Observable from an array of values.
+
+```ts
+import { from, Observable } from 'rxjs';
+
+const multiplyByTen = () => (source) => {
+  return new Observable((subscriber) => {
+    source.subscribe({
+      next(value) { subscriber.next(10 * value); },
+      error(err) { subscriber.error(err); },
+      complete() { subscriber.complete() },
+    });
+  });
+};
+
+const input = from([1, 2, 3, 4]);
+const output = input.pipe(multiplyByTen());
+output.subscribe(x => console.log(x));
+
+// Logs:
+// 10
+// 20
+// 30
+// 40
+```
+
+Notice that a subscribe to `output` will cause the `input` Observable to be subscribed. We call this an "operator subscription chain".
+
+You can also create custom operators by wrapping calls to existing operators. We can reimplement our `multiplyByTen` operator by wrapping the `map` operator which will project our multiplication function over values emitted by the source Observable.
+
+```ts
+import { map } from 'rxjs/operators';
+
+const multiplyByTen = () => map((value) => 10 * value);
+```
+
+## Creation Operators
+
+**What are creation operators?** Besides pipeable operators, creation operators are functions that can be used to create an Observable with some common predefined behavior or by joining other Observables.
+
+A typical example of a creation operator would be the `interval` function. It takes a number (not an Observable) as input argument, and produces an Observable as output:
+
+```ts
+import { interval } from 'rxjs';
+
+const observable = interval(1000 /* number of milliseconds */);
+```
+
+See the list of [all static creation operators here](#creation-operators).
+
+Some *Join Operators* such as `merge`, `combineLatest`, `concat`, etc. take *multiple* Observables as input, not just one, for instance:
+
+```ts
+import { interval, merge } from 'rxjs';
+
+const observable1 = interval(1000);
+const observable2 = interval(400);
+
+const merged = merge(observable1, observable2);
+```
+
+Join operators emit the values of multiple source Observables according to their logic.
+
+## Marble diagrams
+
+To explain how operators work, textual descriptions are often not enough. Many operators are related to time, they may for instance delay, sample, throttle, or debounce value emissions in different ways. Diagrams are often a better tool for that. *Marble Diagrams* are visual representations of how operators work, and include the input Observable(s), the operator and its parameters, and the output Observable.
+
+<span class="informal">In a marble diagram, time flows to the right, and the diagram describes how values ("marbles") are emitted on the Observable execution.</span>
+
+Below you can see the anatomy of a marble diagram.
+
+<img src="assets/images/guide/marble-diagram-anatomy.svg">
+
+Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).
+
+## Categories of operators
+
+There are operators for different purposes, and they may be categorized as: creation, transformation, filtering, joining, multicasting, error handling, utility, etc. In the following list you will find all the operators organized in categories.
+
+For a complete overview, see the [references page](/api).
+
+### Creation Operators
+
+- [`ajax`](/api/ajax/ajax)
+- [`bindCallback`](/api/index/function/bindCallback)
+- [`bindNodeCallback`](/api/index/function/bindNodeCallback)
+- [`defer`](/api/index/function/defer)
+- [`empty`](/api/index/function/empty)
+- [`from`](/api/index/function/from)
+- [`fromEvent`](/api/index/function/fromEvent)
+- [`fromEventPattern`](/api/index/function/fromEventPattern)
+- [`generate`](/api/index/function/generate)
+- [`interval`](/api/index/function/interval)
+- [`of`](/api/index/function/of)
+- [`range`](/api/index/function/range)
+- [`throwError`](/api/index/function/throwError)
+- [`timer`](/api/index/function/timer)
+- [`iif`](/api/index/function/iif)
+
+### Join Creation Operators
+These are Observable creation operators that also have join functionality -- emitting values of multiple source Observables.
+
+- [`combineLatest`](/api/index/function/combineLatest)
+- [`concat`](/api/index/function/concat)
+- [`forkJoin`](/api/index/function/forkJoin)
+- [`merge`](/api/index/function/merge)
+- [`race`](/api/index/function/race)
+- [`zip`](/api/index/function/zip)
+
+### Transformation Operators
+
+- [`buffer`](/api/operators/buffer)
+- [`bufferCount`](/api/operators/bufferCount)
+- [`bufferTime`](/api/operators/bufferTime)
+- [`bufferToggle`](/api/operators/bufferToggle)
+- [`bufferWhen`](/api/operators/bufferWhen)
+- [`concatMap`](/api/operators/concatMap)
+- [`concatMapTo`](/api/operators/concatMapTo)
+- [`exhaust`](/api/operators/exhaust)
+- [`exhaustMap`](/api/operators/exhaustMap)
+- [`expand`](/api/operators/expand)
+- [`groupBy`](/api/operators/groupBy)
+- [`map`](/api/operators/map)
+- [`mapTo`](/api/operators/mapTo)
+- [`mergeMap`](/api/operators/mergeMap)
+- [`mergeMapTo`](/api/operators/mergeMapTo)
+- [`mergeScan`](/api/operators/mergeScan)
+- [`pairwise`](/api/operators/pairwise)
+- [`partition`](/api/operators/partition)
+- [`pluck`](/api/operators/pluck)
+- [`scan`](/api/operators/scan)
+- [`switchMap`](/api/operators/switchMap)
+- [`switchMapTo`](/api/operators/switchMapTo)
+- [`window`](/api/operators/window)
+- [`windowCount`](/api/operators/windowCount)
+- [`windowTime`](/api/operators/windowTime)
+- [`windowToggle`](/api/operators/windowToggle)
+- [`windowWhen`](/api/operators/windowWhen)
+
+### Filtering Operators
+
+- [`audit`](/api/operators/audit)
+- [`auditTime`](/api/operators/auditTime)
+- [`debounce`](/api/operators/debounce)
+- [`debounceTime`](/api/operators/debounceTime)
+- [`distinct`](/api/operators/distinct)
+- [`distinctKey`](../class/es6/Observable.js~Observable.html#instance-method-distinctKey)
+- [`distinctUntilChanged`](/api/operators/distinctUntilChanged)
+- [`distinctUntilKeyChanged`](/api/operators/distinctUntilKeyChanged)
+- [`elementAt`](/api/operators/elementAt)
+- [`filter`](/api/operators/filter)
+- [`first`](/api/operators/first)
+- [`ignoreElements`](/api/operators/ignoreElements)
+- [`last`](/api/operators/last)
+- [`sample`](/api/operators/sample)
+- [`sampleTime`](/api/operators/sampleTime)
+- [`single`](/api/operators/single)
+- [`skip`](/api/operators/skip)
+- [`skipLast`](/api/operators/skipLast)
+- [`skipUntil`](/api/operators/skipUntil)
+- [`skipWhile`](/api/operators/skipWhile)
+- [`take`](/api/operators/take)
+- [`takeLast`](/api/operators/takeLast)
+- [`takeUntil`](/api/operators/takeUntil)
+- [`takeWhile`](/api/operators/takeWhile)
+- [`throttle`](/api/operators/throttle)
+- [`throttleTime`](/api/operators/throttleTime)
+
+### Join Operators
+Also see the [Join Creation Operators](#join-creation-operators) section above.
+
+- [`combineAll`](/api/operators/combineAll)
+- [`concatAll`](/api/operators/concatAll)
+- [`exhaust`](/api/operators/exhaust)
+- [`mergeAll`](/api/operators/mergeAll)
+- [`startWith`](/api/operators/startWith)
+- [`withLatestFrom`](/api/operators/withLatestFrom)
+
+### Multicasting Operators
+
+- [`multicast`](/api/operators/multicast)
+- [`publish`](/api/operators/publish)
+- [`publishBehavior`](/api/operators/publishBehavior)
+- [`publishLast`](/api/operators/publishLast)
+- [`publishReplay`](/api/operators/publishReplay)
+- [`share`](/api/operators/share)
+
+### Error Handling Operators
+
+- [`catchError`](/api/operators/catchError)
+- [`retry`](/api/operators/retry)
+- [`retryWhen`](/api/operators/retryWhen)
+
+### Utility Operators
+
+- [`tap`](/api/operators/tap)
+- [`delay`](/api/operators/delay)
+- [`delayWhen`](/api/operators/delayWhen)
+- [`dematerialize`](/api/operators/dematerialize)
+- [`materialize`](/api/operators/materialize)
+- [`observeOn`](/api/operators/observeOn)
+- [`subscribeOn`](/api/operators/subscribeOn)
+- [`timeInterval`](/api/operators/timeInterval)
+- [`timestamp`](/api/operators/timestamp)
+- [`timeout`](/api/operators/timeout)
+- [`timeoutWith`](/api/operators/timeoutWith)
+- [`toArray`](/api/operators/toArray)
+
+### Conditional and Boolean Operators
+
+- [`defaultIfEmpty`](/api/operators/defaultIfEmpty)
+- [`every`](/api/operators/every)
+- [`find`](/api/operators/find)
+- [`findIndex`](/api/operators/findIndex)
+- [`isEmpty`](/api/operators/isEmpty)
+
+### Mathematical and Aggregate Operators
+
+- [`count`](/api/operators/count)
+- [`max`](/api/operators/max)
+- [`min`](/api/operators/min)
+- [`reduce`](/api/operators/reduce)

--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -25,11 +25,15 @@
 			"title": "Overview",
 			"tooltip": "RxJS Overview",
 			"children": [
-        {
+				{
 					"url": "guide/observable",
 					"title": "Observables"
-        },
-        {
+				},
+				{
+					"url": "guide/operators",
+					"title": "Operators"
+				},
+				{
 					"url": "guide/subscription",
 					"title": "Subscription"
 				},

--- a/docs_app/src/assets/images/guide/marble-diagram-anatomy.svg
+++ b/docs_app/src/assets/images/guide/marble-diagram-anatomy.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="640px" height="396px" viewBox="0 0 640 396" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>marble-diagram-anatomy</title>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="marble-diagram-anatomy">
+            <g id="operator-multiplyByTen" transform="translate(21.907724, 168.854835)">
+                <rect id="Rectangle-1" stroke="#000000" stroke-width="2" x="0" y="0" width="468.757369" height="54.8540876"></rect>
+                <text id="multiplyByTen" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="21.6476967" font-weight="normal" fill="#000000">
+                    <tspan x="169.186646" y="35.2214301">multiplyByTen</tspan>
+                </text>
+            </g>
+            <g id="observable-output" transform="translate(21.907724, 249.101091)">
+                <g id="arrow" transform="translate(0.000000, 6.772110)" stroke="#000000" stroke-width="2" stroke-linecap="square">
+                    <path d="M0.342158664,8 L468.572256,8" id="Line"></path>
+                    <path d="M451.991595,0.338605479 L468.415211,8.46513697" id="Line"></path>
+                    <path d="M451.991595,8.46513697 L468.415211,16.5916685" id="Line" transform="translate(460.203403, 12.528403) scale(1, -1) translate(-460.203403, -12.528403) "></path>
+                </g>
+                <g id="error" transform="translate(273.726931, 4.740477)" stroke="#000000" stroke-width="2" stroke-linecap="square">
+                    <path d="M0.614437261,0.608056568 L21.5910648,21.36685" id="Line" transform="translate(10.949077, 10.835375) scale(1, -1) translate(-10.949077, -10.835375) "></path>
+                    <path d="M0.614437261,0.608056568 L21.5910648,21.36685" id="Line" transform="translate(10.949077, 10.835375) scale(-1, -1) translate(-10.949077, -10.835375) "></path>
+                </g>
+                <g id="marble-40" transform="translate(55.429704, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#FF6946" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="40" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="6.98580227" y="20.7404767">40</tspan>
+                    </text>
+                </g>
+                <g id="marble-60" transform="translate(128.651658, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#FFCB46" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="60" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="6.98580227" y="20.7404767">60</tspan>
+                    </text>
+                </g>
+            </g>
+            <g id="observable-input" transform="translate(21.907724, 112.354919)">
+                <g id="arrow" transform="translate(0.000000, 6.772110)" stroke="#000000" stroke-width="2" stroke-linecap="square">
+                    <path d="M0.342158664,8 L468.572256,8" id="Line"></path>
+                    <path d="M451.991595,0.338605479 L468.415211,8.46513697" id="Line"></path>
+                    <path d="M451.991595,8.46513697 L468.415211,16.5916685" id="Line" transform="translate(460.203403, 12.528403) scale(1, -1) translate(-460.203403, -12.528403) "></path>
+                </g>
+                <path d="M427,0.338605479 L427,30.1358876" id="Line" stroke="#000000" stroke-width="2" stroke-linecap="square" transform="translate(427.000000, 15.237247) scale(1, -1) translate(-427.000000, -15.237247) "></path>
+                <g id="marble-4" transform="translate(55.429704, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#FF6946" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="4" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="11.0203917" y="20.0632657">4</tspan>
+                    </text>
+                </g>
+                <g id="marble-6" transform="translate(128.651658, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#FFCB46" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="6" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="11.0203917" y="20.0632657">6</tspan>
+                    </text>
+                </g>
+                <g id="marble-a" transform="translate(269.621027, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#3EA1CB" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="a" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="10.8986234" y="20.0632657">a</tspan>
+                    </text>
+                </g>
+                <g id="marble-8" transform="translate(342.842981, 0.000000)">
+                    <ellipse id="Oval-1" stroke="#000000" stroke-width="2" fill="#82D736" cx="15.3971399" cy="15.2372465" rx="15.3971399" ry="15.2372465"></ellipse>
+                    <text id="8" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="16.2357725" font-weight="normal" fill="#000000">
+                        <tspan x="11.3625504" y="20.7404767">8</tspan>
+                    </text>
+                </g>
+            </g>
+            <g id="legend-input-observable" transform="translate(8.000000, 10.000000)">
+                <path d="M28.0025541,18.0144658 C4.58101197,34.1485504 -12.2151614,60.0734258 11.4027261,102.132387" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M11.4027261,102.132387 L8.73055297,91.2466396 L3.49896033,94.1844003 L11.4027261,102.132387 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <text id="This-is-time-flowing" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="36.8145623" y="13">This is time flowing from </tspan>
+                    <tspan x="36.8145623" y="30">left to right to represent </tspan>
+                    <tspan x="36.8145623" y="47">the execution of the</tspan>
+                    <tspan x="36.8145623" y="64">input Observable.</tspan>
+                </text>
+            </g>
+            <g id="legend-next" transform="translate(112.716977, 10.000000)">
+                <text id="These-are-values-emi" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="114.362019" y="13">These are values emitted </tspan>
+                    <tspan x="131.303778" y="30">by the Observable.</tspan>
+                </text>
+                <path d="M128.850968,41.3513873 L0.409050692,98.6701421" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M0.409050692,98.6701421 L11.4941232,97.0084658 L9.04897888,91.5292989 L0.409050692,98.6701421 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path d="M147.6673,41.3513873 L67.4933642,97.0324634" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M67.4933642,97.0324634 L78.0752001,93.3358772 L74.652629,88.4077937 L67.4933642,97.0324634 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path d="M186.936166,38.0760299 L193.480977,96.213624" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M193.480977,96.213624 L195.253973,85.145811 L189.291635,85.8170183 L193.480977,96.213624 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path d="M204.934397,36.4383512 L259.747189,97.0324634" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M259.747189,97.0324634 L254.726883,87.0106607 L250.277287,91.0357186 L259.747189,97.0324634 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+            </g>
+            <g id="legend-complete" transform="translate(445.684240, 10.000000)">
+                <text id="This-vertical-line-r" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="22.7499293" y="13">This vertical line represents</tspan>
+                    <tspan x="22.7499293" y="30">the "complete" notification</tspan>
+                    <tspan x="22.7499293" y="47">and indicates that the</tspan>
+                    <tspan x="22.7499293" y="64">Observable has completed</tspan>
+                    <tspan x="22.7499293" y="81">successfully.</tspan>
+                </text>
+                <path d="M13.937921,15.327927 C-0.0407050176,25.019385 -2.50011646,51.8647248 2.86335484,88.0252305" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M2.86335484,88.0252305 L4.24632558,76.9019489 L-1.6887438,77.7822622 L2.86335484,88.0252305 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+            </g>
+            <g id="legend-operator" transform="translate(495.588425, 135.282421)">
+                <text id="This-box-indicates-t" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="8.02410434" y="44.1158954">This box indicates the </tspan>
+                    <tspan x="8.02410434" y="61.1158954">operator which takes </tspan>
+                    <tspan x="8.02410434" y="78.1158954">the input Observable</tspan>
+                    <tspan x="8.02410434" y="95.1158954">(above) to produce the </tspan>
+                    <tspan x="8.02410434" y="112.115895">output Observable </tspan>
+                    <tspan x="8.02410434" y="129.115895">(below). The text inside </tspan>
+                    <tspan x="8.02410434" y="146.115895">the box shows the </tspan>
+                    <tspan x="8.02410434" y="163.115895">nature of the </tspan>
+                    <tspan x="8.02410434" y="180.115895">transformation.</tspan>
+                </text>
+                <path d="M73.4969349,23.2939021 C73.4969349,4.28895214 27.5472993,-17.7526557 0.0451347018,23.293903" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M0.0451347018,23.293903 L8.54901533,15.9915736 L3.56444995,12.651797 L0.0451347018,23.293903 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+            </g>
+            <g id="legend-output-observable" transform="translate(16.181014, 281.035826)">
+                <text id="This-Observable-is-t" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="26.1792443" y="50.6666102">This Observable is the</tspan>
+                    <tspan x="26.1792443" y="67.6666102">output of the operator</tspan>
+                    <tspan x="26.1792443" y="84.6666102">call.</tspan>
+                </text>
+                <path d="M17.5231885,54.8015884 C5.81341019,50.2369613 -11.4758405,28.1704708 11.8624701,0.409419677" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M11.8624701,0.409419677 L2.61633476,6.7457421 L7.20901328,10.6067399 L11.8624701,0.409419677 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+            </g>
+            <g id="legend-error" transform="translate(250.976111, 280.216987)">
+                <text id="This-X-represents-an" font-family="SourceSansPro-Regular, Source Sans Pro" font-size="13.087492" font-weight="normal" fill="#B7178C">
+                    <tspan x="21.270636" y="35.9275019">This X represents an error emitted by</tspan>
+                    <tspan x="21.270636" y="52.9275019">the output Observable, indicating</tspan>
+                    <tspan x="21.270636" y="69.9275019">abnormal termination. Neither values</tspan>
+                    <tspan x="21.270636" y="86.9275019">nor the vertical will be delivered </tspan>
+                    <tspan x="21.270636" y="103.927502">thereafter.</tspan>
+                </text>
+                <path d="M11.4811397,57.3948212 C-6.70631725,51.504022 -3.32492938,12.1184845 25.7701936,0.409419677" id="Line" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+                <path id="Line-decoration-1" d="M25.7701936,0.409419677 L14.6310746,1.65843022 L16.8711257,7.22459325 L25.7701936,0.409419677 Z" stroke="#B7178C" stroke-width="2" stroke-linecap="square"></path>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
* docs(guide): Operator guide for new docs.

This includes updates to the operators guide for consistency with the latest documentation and RxJS v6.

I removed the decision tree widget which may be good to add later.

* docs(guide): Adding operator guide navigation

* docs(guide): cleanup and linking for operators intro

* docs(guide): more separation between pipeable/creation and combining/join operators

* docs(guide): clean up docs and add Stackblitz support

* Add imports for examples
* Use comments for example output for consistency with the rest of the docs.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
