### PR TITLE
Adds fix for NAN value and pressure values outside of device

### DIFF
--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -15,8 +15,8 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
 /* tslint:enable:max-line-length */
 
 /**
- * Returns an Observable that mirrors the first source Observable to emit an item
- * from the combination of this Observable and supplied Observables.
+ * Returns an Observable that mirrors the first source Observable to emit a next,
+ * error or complete notification from the combination of this Observable and supplied Observables.
  * @param {...Observables} ...observables Sources used to race for which Observable emits first.
  * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
  * @method race


### PR DESCRIPTION
* docs(race): Update the race operator  docs

Updating the documentation of  race operator to replace "emits an item" with "emits a next, error or complete notification"  #4561

* updated grammer

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
