### PR TITLE
Allow assignability of non-empty object to generic 

### DIFF
--- a/docs_app/content/guide/observable.md
+++ b/docs_app/content/guide/observable.md
@@ -5,7 +5,7 @@ Observables are lazy Push collections of multiple values. They fill the missing 
 | | Single | Multiple |
 | --- | --- | --- |
 | **Pull** | [`Function`](https://developer.mozilla.org/en-US/docs/Glossary/Function) | [`Iterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) |
-| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](../class/es6/Observable.js~Observable.html) |
+| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](/api/index/class/Observable) |
 
 **Example.** The following is an Observable that pushes the values `1`, `2`, `3` immediately (synchronously) when subscribed, and the value `4` after one second has passed since the subscribe call, then completes:
 

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -71,6 +71,7 @@ export function of<T>(...args: T[]): Observable<T>;
  * // 'next: 10'
  * // 'next: 20'
  * // 'next: 30'
+ * // 'the end'
  *
  * ```
  *
@@ -87,6 +88,7 @@ export function of<T>(...args: T[]): Observable<T>;
  * );
  * // result:
  * // 'next: [1,2,3]'
+ * // 'the end'
  * ```
  *
  * @see {@link from}

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -40,7 +40,7 @@ export function timeoutWith<T, R>(due: number | Date, withObservable: Observable
  * ## Example
  * Add fallback observable
  * ```ts
- * import { intrerval } from 'rxjs';
+ * import { interval } from 'rxjs';
  * import { timeoutWith } from 'rxjs/operators';
  *
  * const seconds = interval(1000);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
