### PR TITLE
Fix resource version precondition on pod delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4516,12 +4516,6 @@
         }
       }
     },
-    "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
-    },
     "mamacro": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -6940,69 +6934,11 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
-    "ts-node": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.1.0.tgz",
-      "integrity": "sha512-mw11Bq08RZgrU/bzcVw/Ti9wNyefpOanXgWsHg008wyVHjvFhWxNatVVrciOAu8BcWSECoNOSunRzUokKH8Mmw==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
-      }
-    },
     "ts-pnp": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.4.tgz",
       "integrity": "sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw==",
       "dev": true
-    },
-    "tsconfig-paths": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.2.0.tgz",
-      "integrity": "sha512-ZnTD/eRbiKg36cxXZgByCahblnv4Upw1/FYTpChFhKuA7W1yM4e0VoPMQoR25GRJ//7zViz/gaH0rbjn4ERPJA==",
-      "dev": true,
-      "requires": {
-        "deepmerge": "^2.0.1",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.1"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
-      }
     },
     "tsconfig-paths-webpack-plugin": {
       "version": "3.2.0",
@@ -7072,6 +7008,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
+        },
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
         }
       }
     },
@@ -7085,17 +7030,6 @@
         "tslib": "^1.8.0",
         "tsutils": "^3.0.0",
         "tsutils-etc": "^1.0.0"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
       }
     },
     "tslint-no-toplevel-property-access": {
@@ -7111,12 +7045,23 @@
       "dev": true,
       "requires": {
         "tsutils": "^2.3.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -7569,12 +7514,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    },
-    "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     },
     "yup": {

--- a/package.json
+++ b/package.json
@@ -141,8 +141,6 @@
     "sinon-chai": "2.14.0",
     "source-map-support": "0.5.3",
     "systemjs": "^0.21.0",
-    "ts-node": "6.1.0",
-    "tsconfig-paths": "3.2.0",
     "tslint": "5.9.1",
     "tslint-etc": "1.9.2",
     "tslint-no-toplevel-property-access": "0.0.2",

--- a/spec/operators/concatWith-spec.ts
+++ b/spec/operators/concatWith-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, Observable } from 'rxjs';
 import { concatWith, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { assertDeepEquals, NO_SUBS } from 'spec/helpers/test-helper';
+import { assertDeepEquals, NO_SUBS } from '../helpers/test-helper';
 
 /** @test {concat} */
 describe('concat operator', () => {

--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -1,5 +1,4 @@
---require ts-node/register
---require tsconfig-paths/register
+--require spec/support/mocha-path-mappings.js
 --require dist/spec/helpers/polyfills.js
 --require dist/spec/helpers/testScheduler-ui.js
 --ui dist/spec/helpers/testScheduler-ui.js

--- a/spec/support/mocha-path-mappings.js
+++ b/spec/support/mocha-path-mappings.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { join } = require('path');
+const root = join(__dirname, '../..');
+
+// We need to intercept the require calls made within the tests to replace
+// paths like 'rxjs/operators' with the relative path to the source files
+// within the 'dist' directory. To do this, we're going to patch the
+// '_resolveFilename' function within Node's built-in 'module'.
+
+const mod = require('module');
+const originalResolveFilename = mod._resolveFilename;
+
+// We've already specified 'paths' within the 'tsconfig.json' file - so that
+// TypeScript is able to find the source files when it's compiling the tests.
+// Now, we just need to change those paths to refer to the 'src' directory
+// that's within the 'dist' directory.
+
+const tsconfig = require(join(root, 'tsconfig.json'));
+const originalPaths = tsconfig.compilerOptions.paths;
+
+const paths = Object.entries(originalPaths).reduce((acc, [key, values]) => {
+  acc[key] = values.map(value => value.replace('/src/', '/dist/src/'));
+  return acc;
+}, {});
+const keys = Object.keys(paths);
+
+mod._resolveFilename = function(path, ...rest) {
+  for (const key of keys) {
+    if (key.endsWith('*')) {
+
+      // If the key ends with a wildcard, we need to take the part of the
+      // original path matched by the wildcard and use it to replace the
+      // wildcard in the mapped path. TypeScript uses this configuration to
+      // support deep paths. (Whilst RxJS does not support deep imports, there
+      // are places in the tests in which deep imports of internals are made.)
+
+      const regExp = new RegExp(key.replace(/\//g, '\\\/').replace(/\*$/, '(.*)'));
+      const match = path.match(regExp);
+      if (match) {
+        const [, more] = match;
+        return originalResolveFilename.call(this, join(root, paths[key][0].replace(/\*$/, more)), ...rest);
+      }
+    } else if (path === key) {
+
+      // If the original path matches the key, we use the mapped path instead.
+
+      return originalResolveFilename.call(this, join(root, paths[key][0]), ...rest);
+    }
+  }
+
+  // Otherwise, we use the original path.
+
+  return originalResolveFilename.call(this, path, ...rest);
+};

--- a/spec/util/toSubscriber-spec.ts
+++ b/spec/util/toSubscriber-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { toSubscriber } from 'src/internal/util/toSubscriber';
+import { toSubscriber } from 'rxjs/internal/util/toSubscriber';
 
 describe('toSubscriber', () => {
   it('should not be closed when other subscriber created with no arguments completes', () => {

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -168,6 +168,7 @@ function shareReplayOperator<T>({
         },
         complete() {
           isComplete = true;
+          subscription = undefined;
           subject.complete();
         },
       });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
